### PR TITLE
Buffer actions on a per-subreddit basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
+*.egg-info/
 .cache/
+.eggs/
 .coverage
 config.json
 config.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+cache: pip
+install:
+  - yes | pip uninstall py pytest
+  - pip install flake8 pydocstyle
+  - python setup.py install
+language: python
+matrix:
+  fast_finish: true
+python:
+  - 3.6
+sudo: false
+script:
+  - flake8 --exclude=examples
+  - pydocstyle bernard
+  - python setup.py test

--- a/bernard/actors.py
+++ b/bernard/actors.py
@@ -351,6 +351,7 @@ class ToolboxNoteAdderLedger(Ledger):
         return json.loads(unzipped.decode())
 
     def __init__(self, *args, **kwargs):
+        """Initialize the ToolboxNoteAdderLedger class."""
         super().__init__(*args, **kwargs)
         self.notes = []
 
@@ -441,6 +442,7 @@ class ToolboxNoteAdder(Subactor):
 class BufferedNote(
         namedtuple('BufferedNote', 'author level link mod text time')):
     """A class for buffered Toolbox usernotes."""
+
     __slots__ = ()
 
     def to_serializable(self, mod_indices, warning_indices):
@@ -458,6 +460,7 @@ class WikiWatcherLedger(Ledger):
     """A class to manage buffered AutoMod updates."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the WikiWatcherLedger class."""
         super().__init__(*args, **kwargs)
         self.placeholder_dict = {}
 

--- a/bernard/browser.py
+++ b/bernard/browser.py
@@ -7,9 +7,10 @@ import prawcore
 class Browser:
     """A class to fetch reports and dispatch to actors."""
 
-    def __init__(self, actors, subreddit, database):
+    def __init__(self, actors, ledgers, subreddit, database):
         """Initialize the Browser class."""
         self.actors = actors
+        self.ledgers = ledgers
         self.subreddit = subreddit
         self.database = database
 
@@ -35,5 +36,5 @@ class Browser:
         """Fetch reports and dispatch to actors."""
         for command, mod, post in self.reports():
             self.check_command(command, mod, post)
-        for actor in self.actors:
-            actor.after()
+        for ledger in self.ledgers:
+            ledger.after()

--- a/bernard/helpers.py
+++ b/bernard/helpers.py
@@ -21,7 +21,7 @@ def update_sr_tables(cursor, subreddit):
     cursor.execute('DELETE FROM subreddit_moderator '
                    'WHERE subreddit_id = ?', (subreddit_id, ))
 
-    for moderator in subreddit.moderator:
+    for moderator in subreddit.moderator():
         cursor.execute('INSERT OR IGNORE INTO users (username) '
                        'VALUES(?)', (str(moderator), ))
         cursor.execute('SELECT id FROM users WHERE username = ?',

--- a/bernard/loader.py
+++ b/bernard/loader.py
@@ -105,7 +105,9 @@ def load_comment_rules(subreddit, rules, ledger_builder, database):
 
 class LedgerBuilder:
     """Provide ledgers for a subreddit configuration."""
+
     def __init__(self, subreddit):
+        """Initialize the ledger class."""
         self.subreddit = subreddit
         self._ledgers = {}
 

--- a/bernard/loader.py
+++ b/bernard/loader.py
@@ -148,7 +148,7 @@ class YAMLLoader:
         subactors = [
             self.parse_subactor_config(subactor_config, subreddit,
                                        ledger_builder, target_types)
-            for subactor_config in actor_config['actions']
+            for subactor_config in actor_config.get('actions', [])
         ]
 
         return actors.Actor(command, target_types, actor_config['remove'],

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test = pytest
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['praw >=4.2, <5.0',
+    install_requires=['praw == 5.0.0dev0',
                       'pyyaml >=3.12, <4.0'],
+    dependency_links=['https://github.com/praw-dev/praw/archive/'
+                      'aabef34146ca23410322d1ccea62fd747afa405d.zip'
+                      '#egg=praw-5.0.0dev0'],
 
     setup_requires=['pytest-runner >=2.1'],
     tests_require=['betamax >=0.8, <0.9',

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,10 @@ setup(
     install_requires=['praw >=4.2, <5.0',
                       'pyyaml >=3.12, <4.0'],
 
-    extras_require={
-        'test': ['betamax >=0.8, <0.9',
-                 'betamax-serializers >=0.2, <0.3',
-                 'mock >=2.0.0, <3.0'],
-    },
+    setup_requires=['pytest-runner >=2.1'],
+    tests_require=['betamax >=0.8, <0.9',
+                   'betamax-matchers >=0.3.0, <0.4',
+                   'betamax-serializers >=0.2, <0.3',
+                   'pytest >=2.7.3'],
+    test_suite='pytest',
 )

--- a/test/cassettes/SystemTest.load.json
+++ b/test/cassettes/SystemTest.load.json
@@ -1,0 +1,226 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-24T18:17:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Jun 2017 18:17:41 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498328261.739247,VS0,VE356",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328260787.Z0FBQUFBQlpUcXpGaHdraGU0WUM5U25PN0VNR1pYdmJFUTFEMjRkZFpONDhvRFFwQ2hiVUl5R01iajFEblJBeFV3SWJNY1ZnX2JzWVBaN1dQR0Z6UmtuVV9QMWY3WEhMcnJrTTlvTS1kRHNMSTBiRVZFQVNDUFZEMk5IU05rNVFiWGhRQlA5cWdkNWo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Jun-2017 20:17:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-24T18:17:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=KJJ0S4TRyf6V2NeD2O; session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328260787.Z0FBQUFBQlpUcXpGaHdraGU0WUM5U25PN0VNR1pYdmJFUTFEMjRkZFpONDhvRFFwQ2hiVUl5R01iajFEblJBeFV3SWJNY1ZnX2JzWVBaN1dQR0Z6UmtuVV9QMWY3WEhMcnJrTTlvTS1kRHNMSTBiRVZFQVNDUFZEMk5IU05rNVFiWGhRQlA5cWdkNWo",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Jun 2017 18:17:41 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1740-ORD",
+          "X-Timer": "S1498328262.522308,VS0,VE62",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUcXpGb3JKdXJvVEgzc08zeHdfeFY1M3B1SkdIYW4wb0VUTGR5NFVURjZJS0hVN3pCb2lhLTlZcFI4Y3ZxQ2ZTbVZpaU9Fc2hCaU9kNXgyLUdOMDJCWjhLLVh1bnlNYjU5X2tweHN4QndGclhjRWhPQkZVdndsUFhWMDJ1dWpEZU50X1o; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 24-Jun-2019 18:17:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "139",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=pAgFMpURPNeF0j0Opt7bsZO%2BAD25mjQcORBJjINSSWOhpO6wUxXRo7wG4LsxQaOZn7GoMgwaWIjIror64%2FRPcU51swpI4nqX",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-24T18:17:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=KJJ0S4TRyf6V2NeD2O; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUcXpGb3JKdXJvVEgzc08zeHdfeFY1M3B1SkdIYW4wb0VUTGR5NFVURjZJS0hVN3pCb2lhLTlZcFI4Y3ZxQ2ZTbVZpaU9Fc2hCaU9kNXgyLUdOMDJCWjhLLVh1bnlNYjU5X2tweHN4QndGclhjRWhPQkZVdndsUFhWMDJ1dWpEZU50X1o; session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328261536.Z0FBQUFBQlpUcXpGMW1lUnAxSlNTRkFONS1wWEZCN1k3ODZZOFM1eHJ2WExNWmxlMjBXSkJObFBEb0JNVWg0TjNyZkc1eGVzQUFkb3hGOUFjRzlYSDE5NUtkSnlZbGpXaWg0bmlmN2staW0xUVdQc3EyTnFzM2c0WHdOcEY3TGJsd3BfOGZWbWtMb20",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 4, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Jun 2017 18:17:41 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1740-ORD",
+          "X-Timer": "S1498328262.623119,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328261641.Z0FBQUFBQlpUcXpGd0g4Njl6S2p6Sll3N1ZUQi1WMWNTTmVoOFhaRUNBY3lNT21BZm1jYXBsSFR1dWlqcDBiSWVpSmxaLWJqZUZvOVNjOV9mbUxzNkJkMjBvQkY3OVNVSjAzT3d1TTdTQmtYU0ozRDZxc0hUYTNhRGF6TElGRG1ydlRXUWxuM2x6alQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Jun-2017 20:17:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "139",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=NMZpb16qhB5h4g5eArxRfmIxm%2Fn7HVIHgttuyI9%2FJcRYN5DG7NmxoWfbf2Vr0UH%2BDCruBN4zlyiyaJmbDMMa7y%2BnztDsTvnM",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-24T18:17:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=KJJ0S4TRyf6V2NeD2O; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUcXpGb3JKdXJvVEgzc08zeHdfeFY1M3B1SkdIYW4wb0VUTGR5NFVURjZJS0hVN3pCb2lhLTlZcFI4Y3ZxQ2ZTbVZpaU9Fc2hCaU9kNXgyLUdOMDJCWjhLLVh1bnlNYjU5X2tweHN4QndGclhjRWhPQkZVdndsUFhWMDJ1dWpEZU50X1o; session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328261641.Z0FBQUFBQlpUcXpGd0g4Njl6S2p6Sll3N1ZUQi1WMWNTTmVoOFhaRUNBY3lNT21BZm1jYXBsSFR1dWlqcDBiSWVpSmxaLWJqZUZvOVNjOV9mbUxzNkJkMjBvQkY3OVNVSjAzT3d1TTdTQmtYU0ozRDZxc0hUYTNhRGF6TElGRG1ydlRXUWxuM2x6alQ",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Jun 2017 18:17:41 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1740-ORD",
+          "X-Timer": "S1498328262.738893,VS0,VE87",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=Q2zQJ1nMdS19MPBStp.0.1498328261757.Z0FBQUFBQlpUcXpGbmZUSnVlVDc2S1FMMS1oMEktVWEtMXBkSzJzMHFCQ1lBWVFWVEFyUXdKVWxmcmhzX2pPSGNSR19HRVM1WmgtbmZRdEVJeFJ2UGw0Vng4cmU4ak1GWmJZY21RT2JCWDVxNGlqWmd2Tjd6Vlo4UmNWSUdzX3hDVEd4Sk1pdmNjeXk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Jun-2017 20:17:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "139",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=8MW2SiHo7e0noDcJCk42CVTAoQEOhs6EaAMFnM98%2BbZkBX2n3%2BzaKbPor63gLC%2B36peVe78jgnVU56QaEYB88JCnqzjUF8CN",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestAutomodWatcher.system.json
+++ b/test/cassettes/TestAutomodWatcher.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestAutomodWatcher.system.json
+++ b/test/cassettes/TestAutomodWatcher.system.json
@@ -1,0 +1,511 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:55:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:51 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498352151.097339,VS0,VE320",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151112.Z0FBQUFBQlpUd29YUzJIcElRbndGNmNDaVlIeEtSTUpELW8zMzc4Z2JWcGkxZFNCU001aGxMeDVrRVVoLU82VFF6Slg4aUVSMGZRS0hzdGlfajlsTTBZUG9GQVpYdnZ1RU5pU1cwb0hFNmJ2TkdjSzdCcV9yZFh4YjBYUnJ3d2F4Nzh2VGdab21VLWg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:51 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151112.Z0FBQUFBQlpUd29YUzJIcElRbndGNmNDaVlIeEtSTUpELW8zMzc4Z2JWcGkxZFNCU001aGxMeDVrRVVoLU82VFF6Slg4aUVSMGZRS0hzdGlfajlsTTBZUG9GQVpYdnZ1RU5pU1cwb0hFNmJ2TkdjSzdCcV9yZFh4YjBYUnJ3d2F4Nzh2VGdab21VLWg",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:51 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.663955,VS0,VE54",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:55:51 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "249",
+          "x-ratelimit-used": "5",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=qFkUNavr0zBBf2OaPBV31q3Fixp4apNnb2WeDLmR3IZ79iY0k7gLioInw%2FHmo2AzCBxVNJU%2FxPDwGXda30YtmEkiH8JvLZ5t",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151678.Z0FBQUFBQlpUd29YTUFTcHFxbXNVLTJKR013YU9NOE1pM2lSUEFFWGtlelNJZGRJTm5hcXRBWFlHZW95OHdPc2tkTWJzak5JOXFSdzBOX3c1WjJ1YmxNVGFpLVM4anUtaHhNT0U5Y2d2RWg3YWFocHI1QVJ3YjJOWkhRbFlLeDJyTWZSamNrTFBjMlY",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 6, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 6, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:51 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.772299,VS0,VE91",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151788.Z0FBQUFBQlpUd29YdWxXakNuTXM4OUY5SmR5dzVLVjZGQXhTNkJ4dmZULVdvYkdpaXhnOVFkZHM2Y3M5YnZIQ1RHUWlEMU5rV09NNEN6bjZ1Q3JUdThOVHhUSlJUSGVRQTFrS1h6SDFFUmpVR24zRFMzdU1yV2hSYnQzOGNEUXZJY2FtV3R6QmF2cDM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:51 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "249",
+          "x-ratelimit-used": "6",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=AmqIWTW7gitd5ehKZfsnpylVs0HlcfxOCE%2FEy0JVjCtfm587oNz1%2B6jvwU%2Fmo055e4Ak%2BuXlRJCBvgq8ziuQIj5RNdgbZ0WC",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151788.Z0FBQUFBQlpUd29YdWxXakNuTXM4OUY5SmR5dzVLVjZGQXhTNkJ4dmZULVdvYkdpaXhnOVFkZHM2Y3M5YnZIQ1RHUWlEMU5rV09NNEN6bjZ1Q3JUdThOVHhUSlJUSGVRQTFrS1h6SDFFUmpVR24zRFMzdU1yV2hSYnQzOGNEUXZJY2FtV3R6QmF2cDM",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.923921,VS0,VE78",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151939.Z0FBQUFBQlpUd29YLWxta1VFbWpTTGZ5VU9ncGw4azBaM1ZPUEVLV3dVaFNPMEg1MHByYm1kYXFjTXlrcnJjdm9oazJHUzYzWDBFT3IzV2s2alRxTjNrSmVpUG1WcTZfTndnb1JWZEVzREpNcmJDY0ExMjJ1UVNNRmxSdkZoMGF2MExfdldCZTJMRVo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:51 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "249",
+          "x-ratelimit-used": "7",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=FfWo%2FJm%2F1GVfiOTyMHOCPKf89Qd3H7bQNsAbIhXIvATi2an%2FJxCASG8yRbCjCOhKh%2Bz0hWPgRC3LDS21TcVBHxz5%2Bf%2BYwHjw",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352151939.Z0FBQUFBQlpUd29YLWxta1VFbWpTTGZ5VU9ncGw4azBaM1ZPUEVLV3dVaFNPMEg1MHByYm1kYXFjTXlrcnJjdm9oazJHUzYzWDBFT3IzV2s2alRxTjNrSmVpUG1WcTZfTndnb1JWZEVzREpNcmJDY0ExMjJ1UVNNRmxSdkZoMGF2MExfdldCZTJMRVo",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"6jbn4r\", \"view_count\": 1, \"secure_media_embed\": {}, \"clicked\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"link_flair_text\": null, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"title\": \"This post will be watched by automod.\", \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"can_gild\": true, \"is_self\": true, \"removed\": false, \"approved\": false, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jbn4r/this_post_will_be_watched_by_automod/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jbn4r\", \"created\": 1498380908.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbn4r/this_post_will_be_watched_by_automod/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498352108.0, \"ups\": 1, \"media\": null, \"ignore_reports\": false, \"mod_reports\": [[\"watch\", \"<USERNAME>\"]], \"visited\": false, \"num_reports\": 1, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1670",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.043368,VS0,VE92",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152063.Z0FBQUFBQlpUd29Zc2FJVWprcmZwa2FIQ3R3djNjdWZ5bXJRWHhKZ2d6TEw3dlZ0Ry1KYlJINmEwalJCVjlFZ2JSaGwwMmRJWGtTZkc1OVFoR0Y0OHhWWTdvSHJhTEVzbDJHWlJaVGozTVRsTUZfX2RzNXFXNzJlS21Kb2hqUEI1Mld6Rk0td3pTOTY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:52 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "592.0",
+          "x-ratelimit-reset": "248",
+          "x-ratelimit-used": "8",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=OmSn7xld7VWxMT91DZbZsFbj5nFZFmn0BKa5cRH0qQe0gWVdY78tzHw27lh%2F0xA8Tvp52K8e4Yd%2FdYDamVp0XE3xIowV0GsI",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbn4r"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "26",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152063.Z0FBQUFBQlpUd29Zc2FJVWprcmZwa2FIQ3R3djNjdWZ5bXJRWHhKZ2d6TEw3dlZ0Ry1KYlJINmEwalJCVjlFZ2JSaGwwMmRJWGtTZkc1OVFoR0Y0OHhWWTdvSHJhTEVzbDJHWlJaVGozTVRsTUZfX2RzNXFXNzJlS21Kb2hqUEI1Mld6Rk0td3pTOTY",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.170523,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152184.Z0FBQUFBQlpUd29ZRUFKNThZSlJhMVpwZHZ0dlNZaGVUbUtBSkNJRmNFek54UU40RWVvUGkycEFyaTBrU0ZzbmxMTmVya3lGbV84MWlxY19WUE9RYjF5MFBEeERwQXc1NDFaMmloaXB6WnFERWhidWlRZ2kxajNfd0lrcnRPTGVzT2ZXaEUzRXJzUUM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:52 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "591.0",
+          "x-ratelimit-reset": "248",
+          "x-ratelimit-used": "9",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152184.Z0FBQUFBQlpUd29ZRUFKNThZSlJhMVpwZHZ0dlNZaGVUbUtBSkNJRmNFek54UU40RWVvUGkycEFyaTBrU0ZzbmxMTmVya3lGbV84MWlxY19WUE9RYjF5MFBEeERwQXc1NDFaMmloaXB6WnFERWhidWlRZ2kxajNfd0lrcnRPTGVzT2ZXaEUzRXJzUUM",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/wiki/revisions/config/automoderator?limit=1&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"timestamp\": 1498380858.0, \"reason\": null, \"author\": {\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"do_not_track\": true, \"show_amp_link\": true, \"live_happening_now\": true, \"adserver_reporting\": true, \"give_hsts_grants\": true, \"legacy_search_pref\": true, \"listing_service_rampup\": true, \"mobile_web_targeting\": true, \"default_srs_holdout\": {\"owner\": \"relevance\", \"variant\": \"popular\", \"experiment_id\": 171}, \"adzerk_do_not_track\": true, \"users_listing\": true, \"show_user_sr_name\": true, \"whitelisted_pms\": true, \"sticky_comments\": true, \"upgrade_cookies\": true, \"ads_prefs\": true, \"block_user_by_report\": true, \"ads_auto_refund\": true, \"orangereds_as_emails\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"expando_events\": true, \"eu_cookie_policy\": true, \"utm_comment_links\": true, \"force_https\": true, \"mobile_native_banner\": true, \"post_to_profile_beta\": true, \"reddituploads_redirect\": true, \"outbound_clicktracking\": true, \"new_loggedin_cache_policy\": true, \"inbox_push\": true, \"scroll_events\": true, \"https_redirect\": true, \"search_dark_traffic\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"pause_ads\": true, \"programmatic_ads\": true, \"geopopular\": true, \"show_recommended_link\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"ads_auction\": true, \"screenview_events\": true, \"new_report_dialog\": true, \"moat_tracking\": true, \"subreddit_rules\": true, \"mobile_settings\": true, \"adzerk_reporting_2\": true, \"activity_service_write\": true, \"ads_auto_extend\": true, \"interest_targeting\": true, \"post_embed\": true, \"new_ads_styles\": {\"owner\": \"cheddar\", \"variant\": \"control_1\", \"experiment_id\": 27}, \"geopopular_gb\": {\"owner\": \"relevance\", \"variant\": \"control_2\", \"experiment_id\": 196}, \"adblock_test\": true, \"activity_service_read\": true}, \"is_friend\": false, \"pref_no_profanity\": true, \"is_suspended\": false, \"subreddit\": null, \"is_sponsor\": false, \"gold_expiration\": null, \"id\": \"xw27h\", \"suspension_expiration_utc\": null, \"verified\": false, \"new_modmail_exists\": false, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": true, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 14, \"inbox_count\": 0, \"pref_top_karma_subreddits\": null, \"has_mail\": false, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"created\": 1463125978.0, \"gold_creddits\": 0, \"created_utc\": 1463097178.0, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true}}, \"page\": \"config/automoderator\", \"id\": \"d1a6ae1a-5940-11e7-88e9-0aa6b855077e\"}], \"after\": \"WikiRevision_d1a6ae1a-5940-11e7-88e9-0aa6b855077e\", \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.312310,VS0,VE112",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152329.Z0FBQUFBQlpUd29ZRndaR254a2xyd1hmZnNjQkdndjdIS3hSRG82aEhLMUdhOG54cEtiQXZ0R1hsVG52UmFrRHlESGVZT2JyQXJzQzVKLW9IekUzOXVCNjJpX3lZR0FUQjl1bW4wc0ZRTDdmVWVicEE4VWF0amRGaXJ2NkZkZlJVSFBWTjdLWUxiM2Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:52 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "590.0",
+          "x-ratelimit-reset": "248",
+          "x-ratelimit-used": "10",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=kPyOKFIa%2BL6gHRVrONEwisCZ3eSxAad0YNq0IaGNbyecWM0wPO1xWRbSaJVI2iVHK2xDPk19KICIyi6jDTtL0cfroHCz0RSL",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/wiki/revisions/config/automoderator?limit=1&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152329.Z0FBQUFBQlpUd29ZRndaR254a2xyd1hmZnNjQkdndjdIS3hSRG82aEhLMUdhOG54cEtiQXZ0R1hsVG52UmFrRHlESGVZT2JyQXJzQzVKLW9IekUzOXVCNjJpX3lZR0FUQjl1bW4wc0ZRTDdmVWVicEE4VWF0amRGaXJ2NkZkZlJVSFBWTjdLWUxiM2Q",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/wiki/config/automoderator?v=d1a6ae1a-5940-11e7-88e9-0aa6b855077e&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"wikipage\", \"data\": {\"may_revise\": true, \"revision_date\": 1498380858.0, \"content_html\": \"\", \"revision_by\": {\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"do_not_track\": true, \"show_amp_link\": true, \"live_happening_now\": true, \"adserver_reporting\": true, \"give_hsts_grants\": true, \"legacy_search_pref\": true, \"listing_service_rampup\": true, \"mobile_web_targeting\": true, \"default_srs_holdout\": {\"owner\": \"relevance\", \"variant\": \"popular\", \"experiment_id\": 171}, \"adzerk_do_not_track\": true, \"users_listing\": true, \"show_user_sr_name\": true, \"whitelisted_pms\": true, \"sticky_comments\": true, \"upgrade_cookies\": true, \"ads_prefs\": true, \"block_user_by_report\": true, \"ads_auto_refund\": true, \"orangereds_as_emails\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"expando_events\": true, \"eu_cookie_policy\": true, \"utm_comment_links\": true, \"force_https\": true, \"mobile_native_banner\": true, \"post_to_profile_beta\": true, \"reddituploads_redirect\": true, \"outbound_clicktracking\": true, \"new_loggedin_cache_policy\": true, \"inbox_push\": true, \"scroll_events\": true, \"https_redirect\": true, \"search_dark_traffic\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"pause_ads\": true, \"programmatic_ads\": true, \"geopopular\": true, \"show_recommended_link\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"ads_auction\": true, \"screenview_events\": true, \"new_report_dialog\": true, \"moat_tracking\": true, \"subreddit_rules\": true, \"mobile_settings\": true, \"adzerk_reporting_2\": true, \"activity_service_write\": true, \"ads_auto_extend\": true, \"interest_targeting\": true, \"post_embed\": true, \"new_ads_styles\": {\"owner\": \"cheddar\", \"variant\": \"control_1\", \"experiment_id\": 27}, \"geopopular_gb\": {\"owner\": \"relevance\", \"variant\": \"control_2\", \"experiment_id\": 196}, \"adblock_test\": true, \"activity_service_read\": true}, \"is_friend\": false, \"pref_no_profanity\": true, \"is_suspended\": false, \"subreddit\": null, \"is_sponsor\": false, \"gold_expiration\": null, \"id\": \"xw27h\", \"suspension_expiration_utc\": null, \"verified\": false, \"new_modmail_exists\": false, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": true, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 14, \"inbox_count\": 0, \"pref_top_karma_subreddits\": null, \"has_mail\": false, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"created\": 1463125978.0, \"gold_creddits\": 0, \"created_utc\": 1463097178.0, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true}}, \"content_md\": \"    author: [do!not!remove!watchlist, ]\\r\\n    action: report\\r\\n    action_reason: \\\"Possibly a spy.\\\"\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2641",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352152.471212,VS0,VE75",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152488.Z0FBQUFBQlpUd29ZbjduVmNNb3N1Z3hpMVk5Y2g1cWZTblozVUQ4Ry1CeC1MNmtZNms5OWRGUGE4OE9tSExOTEFZcS1WNFFJR2NBU0RPNWhPUnFPUHpjVDg0b1ItaHh2bDh4d3lubno1SEhuQTRsdk1KXy1OUzQwNVpQM2RCX0NyUXpfNG4wMExXOW0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:52 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "589.0",
+          "x-ratelimit-reset": "248",
+          "x-ratelimit-used": "11",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=oPR2nNGChZZs8e8eKvuqTn4L2u38nDLHQshhLlHYyz%2BTRki%2B92vAoa0MmYcK2gI3slb1Pl0h9LPeanIYgCMM9pKlDqkvwyvJ",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/wiki/config/automoderator?v=d1a6ae1a-5940-11e7-88e9-0aa6b855077e&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:55:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&content=++++author%3A+%5Bdo%21not%21remove%21watchlist%2C+BJO_test_user%2C+%5D%0D%0A++++action%3A+report%0D%0A++++action_reason%3A+%22Possibly+a+spy.%22&page=config%2Fautomoderator&previous=d1a6ae1a-5940-11e7-88e9-0aa6b855077e"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "240",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=H7nO0YRyMqAgdyfQrA; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd29YUkphUWtfcXozTGhvV1k5Y2R6M2NuMUNQR2ZKRHM1VXBRUG11NFg5ZU1VTDNnREdVWVRyOEZKcGVrTllwcGpIRWVIZGtuUV9mUnd1Y1VXOG5SSC01M1c3Y1AyblRfMld1YktpWHh0T1BUMlBFMXItTVlZRU14OFNZRTdqanVTQVM; session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152488.Z0FBQUFBQlpUd29ZbjduVmNNb3N1Z3hpMVk5Y2g1cWZTblozVUQ4Ry1CeC1MNmtZNms5OWRGUGE4OE9tSExOTEFZcS1WNFFJR2NBU0RPNWhPUnFPUHpjVDg0b1ItaHh2bDh4d3lubno1SEhuQTRsdk1KXy1OUzQwNVpQM2RCX0NyUXpfNG4wMExXOW0",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/api/wiki/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:55:52 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498352153.614587,VS0,VE114",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=88IsS4hGHkGYfHzmIt.0.1498352152637.Z0FBQUFBQlpUd29ZS1JvaDREem9mRW52MDRaNk5UZHI0MFVnUUIzcGhaZHRZYk5zZGN3a0NPcmowNUlVM21HbEhWNEVjNzNVaDZmMGtmWS1BQnZiN0w5WGhUUW9SNXRMSTgzUEF6eXJVMl9SalNiQno3TmRoajB3b0lyeTZqdm84bTd4NVJoV0NYOUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:55:52 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "588.0",
+          "x-ratelimit-reset": "248",
+          "x-ratelimit-used": "12",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/api/wiki/edit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestBanner.system.json
+++ b/test/cassettes/TestBanner.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestBanner.system.json
+++ b/test/cassettes/TestBanner.system.json
@@ -1,0 +1,454 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:31:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1727-ORD",
+          "X-Timer": "S1498350687.998640,VS0,VE374",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350687037.Z0FBQUFBQlpUd1JmOEZPZ2NlQzVCTnY1WnNXVzdUZG1rcFMxamZYTmRpZW5BQ1d4akVVMHExUkRzSkxGamduS1VCYkFlUktCSWV2V2w3elotRVJoSWxGZVdORWE3VGVRVFNGSUtMQnkxS0ZPOTFHMG1jVGZHTHhYTFdJcVZQUjY0LTE4aVhmcmR5aUM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350687037.Z0FBQUFBQlpUd1JmOEZPZ2NlQzVCTnY1WnNXVzdUZG1rcFMxamZYTmRpZW5BQ1d4akVVMHExUkRzSkxGamduS1VCYkFlUktCSWV2V2w3elotRVJoSWxGZVdORWE3VGVRVFNGSUtMQnkxS0ZPOTFHMG1jVGZHTHhYTFdJcVZQUjY0LTE4aVhmcmR5aUM",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350688.571371,VS0,VE58",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:31:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=qZ6iZJgRJdWlk1U2HTqt7Gr9096dODIgc%2BwwH9G%2BKGXzhZNhfHQy42H9jKIlYHPLJCg069m69nIzXpBp070CX5oMKJTGIr7O",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350687587.Z0FBQUFBQlpUd1JmckdaTHlXQW9BQnpXbmMzWmRQYVpSN3VzVkJJUUpzYW43dmRGVkYyYUxXemJXTy1NX0o2cVdBbUdwQmNkXzlFVWh3eFhNMWFrWDkxZ0NXY0dPWWtGMmdLZ1BjWTVITnpWX2ZrZlRFTGZQUHRPTUgxMEw4VlRpY1h5MUt5MDE5Yl8",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 3, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 3, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350688.697292,VS0,VE606",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350687706.Z0FBQUFBQlpUd1JnRkRveXRRc3hsRExoMDNlbm1TeEhKdXlkcjlDMS1TV1p3c0pNcllxd1lfMkpIUDlmdHpZYVRJWXdYRjRzenpnenJ1Wl95WG1CZC1qRWR5TlBYYnFORlY0eDA2UVdYZzFUTmlEbVQySVFQWGpUdFhHd1dJSDQxdkx4SXlRWE81aXk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=3ePnwK3Dtz5U0LKFGPF3MvZ%2BCNh3ox9pH0dpnrI2JREgJS4JYi7JmfE%2FqX2%2FEfVsdDdUq9lLPu%2Bq%2Bx98ndwTMXP5sJFFoQ%2Bz",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350687706.Z0FBQUFBQlpUd1JnRkRveXRRc3hsRExoMDNlbm1TeEhKdXlkcjlDMS1TV1p3c0pNcllxd1lfMkpIUDlmdHpZYVRJWXdYRjRzenpnenJ1Wl95WG1CZC1qRWR5TlBYYnFORlY0eDA2UVdYZzFUTmlEbVQySVFQWGpUdFhHd1dJSDQxdkx4SXlRWE81aXk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350688.382247,VS0,VE244",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688406.Z0FBQUFBQlpUd1JnNEZwckN2MjEyUGhaWlBkZE1GNzdMcnB4WnNjN19JakFuMlBfZUxEZE1La3pBSldNdXRYbUlZeXZZaGtsdEI5ci13ZUNKbjdIemtyZGRvaldmMF9YdjBNZmxMMHpmdkZoVFJGNExMM2FlMUh3U0JEUEFpekhDNWJISmhEeG9OcWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=QpyaNZQzsUkSrDaSWmgTLwi5snAvisvIXs4qsfl7xtwDntsvJhJJoQE9XOttHGT5ChPLJnxdOr%2F34%2B0aHCaZHBobDJVwA6Rv",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688406.Z0FBQUFBQlpUd1JnNEZwckN2MjEyUGhaWlBkZE1GNzdMcnB4WnNjN19JakFuMlBfZUxEZE1La3pBSldNdXRYbUlZeXZZaGtsdEI5ci13ZUNKbjdIemtyZGRvaldmMF9YdjBNZmxMMHpmdkZoVFJGNExMM2FlMUh3U0JEUEFpekhDNWJISmhEeG9OcWk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"6jbj2o\", \"view_count\": 1, \"secure_media_embed\": {}, \"clicked\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"link_flair_text\": null, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"title\": \"This post will result in a ban.\", \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"can_gild\": true, \"is_self\": true, \"removed\": false, \"approved\": false, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jbj2o/this_post_will_result_in_a_ban/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jbj2o\", \"created\": 1498379403.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbj2o/this_post_will_result_in_a_ban/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498350603.0, \"ups\": 1, \"media\": null, \"ignore_reports\": false, \"mod_reports\": [[\"b\", \"<USERNAME>\"]], \"visited\": false, \"num_reports\": 1, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1648",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350689.671702,VS0,VE72",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688690.Z0FBQUFBQlpUd1JnUUoxdHJBUFFGaTF3M2ZYY2t1c2RCUW9nYnk3MWM1SERMaVB5SmRReDdEX0pFb213QWM1ZFVIRDMyV0VvU0V5Q1dJVnJSU3BkVzlpck93ZnNSTk9nVU1oejd0UkgwZXIyYndwbHN1enFBUzNLX2xaelBWMVZrM2RWU3piTTBtcU4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "4",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=KTJiSSNEcpZ%2BmYuSjRDEw%2BHAbWw3xtE%2FatqXP%2BSW2SSVsNuHKb5AfI7FOlHSB0O0QNBBLUifQpBbQTUnK7Lw0E6HAve7Q%2Bt9",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&ban_message=Psychologism+is+looked+upon+with+suspicion+in+%2Fr%2FThirdRealm.+Take+a%0Afew+days+to+reconsider+your+ontological+commitments.%0A%0A%0AThis+action+was+taken+because+of+the+following+post%3A+%2Fr%2FThirdRealm%2Fcomments%2F6jbj2o%2Fthis_post_will_result_in_a_ban%2F&ban_reason=psychologism+-+by+<USERNAME>&duration=3&name=BJO_test_user&type=banned"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "373",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688690.Z0FBQUFBQlpUd1JnUUoxdHJBUFFGaTF3M2ZYY2t1c2RCUW9nYnk3MWM1SERMaVB5SmRReDdEX0pFb213QWM1ZFVIRDMyV0VvU0V5Q1dJVnJSU3BkVzlpck93ZnNSTk9nVU1oejd0UkgwZXIyYndwbHN1enFBUzNLX2xaelBWMVZrM2RWU3piTTBtcU4",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/api/friend/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350689.784445,VS0,VE213",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688805.Z0FBQUFBQlpUd1JnLWsxcXQxNy1mbjUyNmRnQUFEY1ZyeVZOWENiQnNmUGhyOHZKLUlhTTFiclp4MFNZamNuRGdlekg0QmV4VWVkcEtSZ0JTU2M5QkhKSV9KbnlyQUlBUE1RTjVsWFMyXzdWdWpIdWpCcTYzdVhwWEtMNnVIMWt0T0F3VHl5dU1JS1o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/api/friend/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbj2o&spam=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "37",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350688805.Z0FBQUFBQlpUd1JnLWsxcXQxNy1mbjUyNmRnQUFEY1ZyeVZOWENiQnNmUGhyOHZKLUlhTTFiclp4MFNZamNuRGdlekg0QmV4VWVkcEtSZ0JTU2M5QkhKSV9KbnlyQUlBUE1RTjVsWFMyXzdWdWpIdWpCcTYzdVhwWEtMNnVIMWt0T0F3VHl5dU1JS1o",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350689.049029,VS0,VE133",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350689065.Z0FBQUFBQlpUd1JoTzlpd2tQdjlmejNublhaTWVVUjVsam5haFJ6NlVzLV85Unk0bEtJSElIT0lUUVk2WFQzNWIxRlR0bkpDUUpBTE9OVEtuaXFFdHBocEpySGZveXJJWTlieWtiVWRzYVJwUzhBUmZOYVpLQlRRTUtZdDQ0a05oMUp3azJtUVVRRFM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "6",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:31:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbj2o"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "26",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=sLTiINNGD8XE9yWLzu; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd1JmamZtaEhrT2M5UFVRcFRfdnVlbjQyRGcwVWNzY0JUbHV0Q0NVZ1ZyRE9pWldsT3ZNQ0x5cTVxX2M1SkM4TXkwbkgwZXV3V19YSDdUT1FZZU10blh6cU14SFVjVTQ5TDY3N25zeDZCRi1CaFpvZ2NGc3NvZEFqb01KcG9aSk9BRlQ; session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350689065.Z0FBQUFBQlpUd1JoTzlpd2tQdjlmejNublhaTWVVUjVsam5haFJ6NlVzLV85Unk0bEtJSElIT0lUUVk2WFQzNWIxRlR0bkpDUUpBTE9OVEtuaXFFdHBocEpySGZveXJJWTlieWtiVWRzYVJwUzhBUmZOYVpLQlRRTUtZdDQ0a05oMUp3azJtUVVRRFM",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/lock/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:31:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1739-ORD",
+          "X-Timer": "S1498350689.224182,VS0,VE60",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=DoBFzDH5Nu4d2jzNLx.0.1498350689260.Z0FBQUFBQlpUd1Jod1VCYi1oTW1fZTJJWGVlUWtZVFZCYkNkWG0zQldqUjVmV2VlX0ZFLWRpTWsxN3pBeEI3bHRnampHLWRrQ1pTUVcydy1FOVQ2RTcxNGN5ekNRVjh0VUkwVWMxSFpFS09WTjhZU0FBMmFtVU84b2hEV0l1LUVhajdKajdGLWhkYS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:31:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "7",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/lock/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestNotifier.system.json
+++ b/test/cassettes/TestNotifier.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestNotifier.system.json
+++ b/test/cassettes/TestNotifier.system.json
@@ -1,0 +1,456 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:20:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1733-ORD",
+          "X-Timer": "S1498350008.920267,VS0,VE330",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350007941.Z0FBQUFBQlpUd0c0dkx2cHpkMnBMSHh2QVk0d0tNQkxqZUdFVURWWjZnR2NNbEJ2c0MxZktGRVJxRU9jbS1KbldGTE5keUg1MU9nNndmTGdLbk5zcmZMVWV2cGtKZjhTNEpLSHg5Q0o5VEFkakhOYXoxME5hNDAxUjRzQUItTDJsaThsd3k5LWVnSE0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:08 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350007941.Z0FBQUFBQlpUd0c0dkx2cHpkMnBMSHh2QVk0d0tNQkxqZUdFVURWWjZnR2NNbEJ2c0MxZktGRVJxRU9jbS1KbldGTE5keUg1MU9nNndmTGdLbk5zcmZMVWV2cGtKZjhTNEpLSHg5Q0o5VEFkakhOYXoxME5hNDAxUjRzQUItTDJsaThsd3k5LWVnSE0",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350008.459905,VS0,VE63",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:20:08 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "592",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=W6Wu87OTO4bC6CZIyEsYILeUjIz9LwNTGqLfJ2EdGo%2BD9ngtP3%2FzQp9bKZq8FyWz7zKe6wgjobD8BtYk5wxNEhAS0NNF4Y4V",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008480.Z0FBQUFBQlpUd0c0VWlEX3FYX3JLaGZULWNPSkZILXBiWXNCVWJzNW14LWREdTVpVFFzOXpHTjBRbUZwUFpJbmVHWEx0VHo5Wm5qWldTVWVHRmkzN0hTQlBTMjA2ejFXdWdpWXdJYkpaREJYdllTTVV4a0JOX01tdFRUdThKOHU0MTlPVmVYTTM3WG4",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 4, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 4, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.565907,VS0,VE86",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008583.Z0FBQUFBQlpUd0c0RkJVbFRLUlB5c3Q2cmpSdGNHWXpUV0NwZ2pOTXF1eV9XRHQ0S2czZGVnUktUOVdfb2NibHNMYmNfZkZoZjJrclktOTgyUEE0c25NZU1kVzR1cUpaSzYtTjFXWTA4Xy1sNXpFT243R2pYN2hTWURGY21xMVo4cWFSU0lmRzFlSW0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:08 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "592",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=PSB0ET4MRVaBaEBgY5MJlDoQnuZ26kE3o%2BDRUHj0KppoZia46%2B1tBeeuq40hhk3GNLFscRI1vO8duJI3L439P%2FRg2i0WozwA",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008583.Z0FBQUFBQlpUd0c0RkJVbFRLUlB5c3Q2cmpSdGNHWXpUV0NwZ2pOTXF1eV9XRHQ0S2czZGVnUktUOVdfb2NibHNMYmNfZkZoZjJrclktOTgyUEE0c25NZU1kVzR1cUpaSzYtTjFXWTA4Xy1sNXpFT243R2pYN2hTWURGY21xMVo4cWFSU0lmRzFlSW0",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.687745,VS0,VE156",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008805.Z0FBQUFBQlpUd0c0TDh0VHNSeHhuTk15QU5qRzJBMzgta0xGYUh2bFpDeElqckpPYmlxWTY3YXVsbGxOZXcyT0c3ZE1Sb0Jydm9XNnM4YWlGYkRPcS1EbFRyVjlQRXhQZFpMcXZmdXNKeWRYT0RVcHhtekRBdnc5ZlZGVWZhTV9IaW5DNEZvMGZjbS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:08 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "592",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=rx8ngUxXnERCgiR50Uk2F9tYUrX%2F1hcg%2BBb9oI%2BSrczVc32cTErKGWQevv3e4Imr1l%2FtdLUUXpFbnWkBgdupo5wYfxLHJBQ6",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008805.Z0FBQUFBQlpUd0c0TDh0VHNSeHhuTk15QU5qRzJBMzgta0xGYUh2bFpDeElqckpPYmlxWTY3YXVsbGxOZXcyT0c3ZE1Sb0Jydm9XNnM4YWlGYkRPcS1EbFRyVjlQRXhQZFpMcXZmdXNKeWRYT0RVcHhtekRBdnc5ZlZGVWZhTV9IaW5DNEZvMGZjbS0",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"6jbhf9\", \"view_count\": 1, \"secure_media_embed\": {}, \"clicked\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"link_flair_text\": null, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"title\": \"This post will receive a notification.\", \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"can_gild\": true, \"is_self\": true, \"removed\": false, \"approved\": false, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jbhf9\", \"created\": 1498378796.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498349996.0, \"ups\": 1, \"media\": null, \"ignore_reports\": false, \"mod_reports\": [[\"w\", \"<USERNAME>\"]], \"visited\": false, \"num_reports\": 1, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1669",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.885849,VS0,VE80",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008905.Z0FBQUFBQlpUd0c0NGNBYWFFaVE5UG9Ec3J0N2ttMkV5YU1EZGVRU1dXelBnT0x5ZmxMNzdNYnhnVm5JLWpSeHNLbWZ6QlR3UFBzTkhXcFVaU3JHbnlKUE5QeWM2RzVUbE9RWnRNNl9RZEVHdEZZS0FNS1dvRXI1Q3J3MXF1cjg2MEFxOU1XUWJDUFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:08 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "592",
+          "x-ratelimit-used": "4",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=1H5u0W7PkTMOZMEGbV5wg6vdLeOk94ynZAQqVmeldxX3nwel2kb2mVWMLAfhSnhxR1pEk7z9q6WFieTD8PyP9EBZIbrOMxl6",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&text=Please+keep+our+rules+in+mind%21%0A%0A-----%0A%0AI+am+a+bot.+Please+do+not+reply+to+this+message%2C+as+it+will+go+unread.+Instead%2C+%5Bcontact+the+moderators%5D%28https%3A%2F%2Fwww.reddit.com%2Fmessage%2Fcompose%3Fto%3D%252Fr%252FThirdRealm%26message%3DPost%2520in%2520question%3A%2520%2Fr%2FThirdRealm%2Fcomments%2F6jbhf9%2Fthis_post_will_receive_a_notification%2F%29+with+questions+or+comments.&thing_id=t3_6jbhf9"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "435",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350008905.Z0FBQUFBQlpUd0c0NGNBYWFFaVE5UG9Ec3J0N2ttMkV5YU1EZGVRU1dXelBnT0x5ZmxMNzdNYnhnVm5JLWpSeHNLbWZ6QlR3UFBzTkhXcFVaU3JHbnlKUE5QeWM2RzVUbE9RWnRNNl9RZEVHdEZZS0FNS1dvRXI1Q3J3MXF1cjg2MEFxOU1XUWJDUFg",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/comment/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_6jbhf9\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"djczmav\", \"gilded\": 0, \"archived\": false, \"score\": 1, \"report_reasons\": [], \"author\": \"<USERNAME>\", \"parent_id\": \"t3_6jbhf9\", \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"controversiality\": 0, \"body\": \"Please keep our rules in mind!\\n\\n-----\\n\\nI am a bot. Please do not reply to this message, as it will go unread. Instead, [contact the moderators](https://www.reddit.com/message/compose?to=%2Fr%2FThirdRealm\\u0026message=Post%20in%20question:%20/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/) with questions or comments.\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPlease keep our rules in mind!\\u003C/p\\u003E\\n\\n\\u003Chr/\\u003E\\n\\n\\u003Cp\\u003EI am a bot. Please do not reply to this message, as it will go unread. Instead, \\u003Ca href=\\\"https://www.reddit.com/message/compose?to=%2Fr%2FThirdRealm\\u0026amp;message=Post%20in%20question:%20/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\\\"\\u003Econtact the moderators\\u003C/a\\u003E with questions or comments.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"name\": \"t1_djczmav\", \"score_hidden\": false, \"num_reports\": 0, \"stickied\": false, \"created\": 1498378809.0, \"subreddit\": \"ThirdRealm\", \"author_flair_text\": \"ayy lmao\", \"spam\": false, \"created_utc\": 1498350009.0, \"distinguished\": null, \"ignore_reports\": false, \"mod_reports\": [], \"subreddit_type\": \"private\", \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1747",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:09 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.010776,VS0,VE112",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350009031.Z0FBQUFBQlpUd0c1U0Z0Tm1tVlh4ZnNmMTNMdlJvLUJuYVpZNXplZGxQTUlDaXZOOXlESzJHcmdvQkZWSDhBUGVaQ1l1NUlJaUg0ZUZtZExVbC1jZUVuS2tiQ3hoMXRWVTJTUGtoaGR3OUswSTFpci1pbTJIV2xSeGhmMVJiTjlycm9MaFVvSlR2eXk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:09 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "591",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/comment/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&how=yes&id=t1_djczmav&sticky=True"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350009031.Z0FBQUFBQlpUd0c1U0Z0Tm1tVlh4ZnNmMTNMdlJvLUJuYVpZNXplZGxQTUlDaXZOOXlESzJHcmdvQkZWSDhBUGVaQ1l1NUlJaUg0ZUZtZExVbC1jZUVuS2tiQ3hoMXRWVTJTUGtoaGR3OUswSTFpci1pbTJIV2xSeGhmMVJiTjlycm9MaFVvSlR2eXk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/distinguish/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_6jbhf9\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"djczmav\", \"gilded\": 0, \"archived\": false, \"score\": 1, \"report_reasons\": [], \"author\": \"<USERNAME>\", \"parent_id\": \"t3_6jbhf9\", \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"controversiality\": 0, \"body\": \"Please keep our rules in mind!\\n\\n-----\\n\\nI am a bot. Please do not reply to this message, as it will go unread. Instead, [contact the moderators](https://www.reddit.com/message/compose?to=%2Fr%2FThirdRealm\\u0026message=Post%20in%20question:%20/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/) with questions or comments.\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPlease keep our rules in mind!\\u003C/p\\u003E\\n\\n\\u003Chr/\\u003E\\n\\n\\u003Cp\\u003EI am a bot. Please do not reply to this message, as it will go unread. Instead, \\u003Ca href=\\\"https://www.reddit.com/message/compose?to=%2Fr%2FThirdRealm\\u0026amp;message=Post%20in%20question:%20/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\\\"\\u003Econtact the moderators\\u003C/a\\u003E with questions or comments.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"name\": \"t1_djczmav\", \"score_hidden\": false, \"num_reports\": 0, \"stickied\": true, \"created\": 1498378809.0, \"subreddit\": \"ThirdRealm\", \"author_flair_text\": \"ayy lmao\", \"spam\": false, \"created_utc\": 1498350009.0, \"distinguished\": \"moderator\", \"ignore_reports\": false, \"mod_reports\": [], \"subreddit_type\": \"private\", \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1753",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:09 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.172475,VS0,VE93",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350009193.Z0FBQUFBQlpUd0c1eWlkb2NtRHY0dEk2Zk5DZWVGQUtNbENfOGszTWdHOUctVDdnUDFXaWsxVWIzUGRDRUp5VFFETDlZQVU2Q3ZCSXNtVXUwZ2hscVd1cXNiTWxoRUNMRHowR2tZUXVOVUxGQS14X1JnVGZOSzN4S0xzN20xNWt1bllySDRCc1hvYXo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:09 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "591",
+          "x-ratelimit-used": "6",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/distinguish/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:20:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbhf9"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "26",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=BW8e08f2KV8JP5ZKBR; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0c0NjFnaW0tR3V0M0loSUNMUGZIa2s3bWlKVEllbzhINmVQQ1gxZXZNakhZOEU2TjZPZk1IYi1mLXI2OVVvMXVtWmJ2U01MYUlxUFRiYWZJRDg0S2xvWmZTYk5IQ2JJMGNlZjBCLVJhTVd1b2hLOUZQX2lDbDRMWFlzZUZCQmZtSWc; session_tracker=B4wrGec9dWe2rzZI1l.0.1498350009193.Z0FBQUFBQlpUd0c1eWlkb2NtRHY0dEk2Zk5DZWVGQUtNbENfOGszTWdHOUctVDdnUDFXaWsxVWIzUGRDRUp5VFFETDlZQVU2Q3ZCSXNtVXUwZ2hscVd1cXNiTWxoRUNMRHowR2tZUXVOVUxGQS14X1JnVGZOSzN4S0xzN20xNWt1bllySDRCc1hvYXo",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:20:09 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350009.308256,VS0,VE142",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=B4wrGec9dWe2rzZI1l.0.1498350009328.Z0FBQUFBQlpUd0c1TDI1dmNwb1NQZGstYy03dnA3SlJ6YmpsRmJFTTdZSTVrOUVMYmdOcG1BSWdXZUJqQkRJLWdmZV9LZmc3aGF2dTZUckdqMnlmVmY3aHY4UmxoVzRMRGNJQ3BDdWxXLWx2NkNxYzBUaDdfTWxRNDBkMm9aNUN2N2tnc21xNVgzVGE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:20:09 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "591",
+          "x-ratelimit-used": "7",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestNuker.system.json
+++ b/test/cassettes/TestNuker.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestNuker.system.json
+++ b/test/cassettes/TestNuker.system.json
@@ -1,0 +1,454 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:27:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:05 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1742-ORD",
+          "X-Timer": "S1498350426.530603,VS0,VE335",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350425547.Z0FBQUFBQlpUd05aSHMtRElpdTNPOUNNbWJIbG9nbVgySk9lbmNjQk1ZbUhfRXJFMkhZVjlNSzI2TEEwQUstcEJfUjRPYklwTlRybVBjVTd5aGJTMTZPdmVNOU93Rnk3djdXZzhZNEV0RlhHOWZyc18tY00tTEY0WXZXeHdkSW1OYW5FMWp2SWRjVVc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:05 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350425547.Z0FBQUFBQlpUd05aSHMtRElpdTNPOUNNbWJIbG9nbVgySk9lbmNjQk1ZbUhfRXJFMkhZVjlNSzI2TEEwQUstcEJfUjRPYklwTlRybVBjVTd5aGJTMTZPdmVNOU93Rnk3djdXZzhZNEV0RlhHOWZyc18tY00tTEY0WXZXeHdkSW1OYW5FMWp2SWRjVVc",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:06 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350426.125353,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:27:06 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "578.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "22",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=bEkxW0KFbInWmoWL17WiP8EDl%2BD5QZoKmBw8gv%2BehMqO13t8wlFycrV%2F1%2B6N%2Bd4olttorOVbRgf2z57YeYePBjJkADYASHRr",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426145.Z0FBQUFBQlpUd05hb05YQ2tDZm9nNks3dkJUZGgwNU1sV2ktQkVycVUwcmRqeF9yX1lRU2ZEVTFwaVNTTFVmdlRfLUNJdXlXLWNWdmdNQWFQVjBobVBtR0ptTE5nSE1yQmNoLXZkRVVjVXN0Ykd0b3R2Ti1faUV1Vmo4NGtPRFRSZll3RTl3cGd2X0c",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 5, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 5, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:06 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350426.242750,VS0,VE76",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426263.Z0FBQUFBQlpUd05hbjVndEdDUlhCeWN0eEdjTnlKbXpwa29YMDBUSVpNZVVXYTlrcVpmZFhUbFZSdGUyNXdmVjlKX0NaUnQtWmlKZGZqZHN5ODRJOERvdTQxTlFrbVZJYUJzS1RBcDAwcC1OTWZvdTROOFZiRUhOWlRmRktsS1hXZVdIUjJqUHVqQjc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:06 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "577.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "23",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=tGxB94DJ9QFqjk0dmY5OkTTS2xbUhPc2WTLsqbi4zFXdSlXuUnEa3AkA%2FT4mz%2BUMrjrzR1T1flWkNg1fGURqKguEA2FfOzcM",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426263.Z0FBQUFBQlpUd05hbjVndEdDUlhCeWN0eEdjTnlKbXpwa29YMDBUSVpNZVVXYTlrcVpmZFhUbFZSdGUyNXdmVjlKX0NaUnQtWmlKZGZqZHN5ODRJOERvdTQxTlFrbVZJYUJzS1RBcDAwcC1OTWZvdTROOFZiRUhOWlRmRktsS1hXZVdIUjJqUHVqQjc",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:06 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350426.358425,VS0,VE279",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426390.Z0FBQUFBQlpUd05hZUVGN1prXzFnbnlQa0IzNHVhSWIxZlBkM05MNWEyazE3alJ2QU5CMUhYaTlvOVhIeXNzVDVZYVdFWWpzM1luQVlFaGdQT3JISUFRd2JsZTJmemtCcW5CSHpYeXlTN0VJbURwb1ZTNlJjbjRfU2RjWXJiQUh5aUM2X1RCdWZKMmw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:06 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "576.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "24",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=EtlplmWWZU3G0XhICmuZrnxBnl08mclOqu48Mz8iao9V%2BTzcmnGbBRZa0%2FlbPH9W7O40Z9iThzFF3Q68rH%2FKSV%2FyJJ2%2FTlND",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426390.Z0FBQUFBQlpUd05hZUVGN1prXzFnbnlQa0IzNHVhSWIxZlBkM05MNWEyazE3alJ2QU5CMUhYaTlvOVhIeXNzVDVZYVdFWWpzM1luQVlFaGdQT3JISUFRd2JsZTJmemtCcW5CSHpYeXlTN0VJbURwb1ZTNlJjbjRfU2RjWXJiQUh5aUM2X1RCdWZKMmw",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"link_title\": \"This post will receive a notification.\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_6jbhf9\", \"link_author\": \"BJO_test_user\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"djczsed\", \"gilded\": 0, \"archived\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"num_comments\": 3, \"ups\": 1, \"parent_id\": \"t3_6jbhf9\", \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"controversiality\": 0, \"body\": \"This comment will be nuked.\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis comment will be nuked.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"stickied\": false, \"can_gild\": true, \"removed\": false, \"approved\": false, \"score_hidden\": false, \"subreddit_type\": \"private\", \"link_permalink\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\", \"name\": \"t1_djczsed\", \"created\": 1498379081.0, \"subreddit\": \"ThirdRealm\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498350281.0, \"distinguished\": null, \"ignore_reports\": false, \"mod_reports\": [[\"n\", \"<USERNAME>\"]], \"num_reports\": 1, \"link_url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\"}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1555",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:06 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350427.684891,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426713.Z0FBQUFBQlpUd05hdG01dlV6Yk55alNTSHA1ZWZiQUg1Zjk5UHh3ZENoeEtLVW82TTg2OERuWGtKcERxQllVUDVjaTdDdDVHcEVFZHdMQVJ2c2d4a05XOGJzT0ZneFozelRRMkhmYjVwUGVEQ0RRWGFxdUhldmFwN1llcHJtWFVUQ2JzdW9hWUZHOEg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:06 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "575.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "25",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=LjZWQhKSzj3af61JMwvgDNeMUuuhHZC%2Fqfy6zQnaIKPs3BNKtlmPd9hiVJiWhgv%2Ftn8zgdlLpzafCL3drC8e1a9xPmuDvAe%2F",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426713.Z0FBQUFBQlpUd05hdG01dlV6Yk55alNTSHA1ZWZiQUg1Zjk5UHh3ZENoeEtLVW82TTg2OERuWGtKcERxQllVUDVjaTdDdDVHcEVFZHdMQVJ2c2d4a05XOGJzT0ZneFozelRRMkhmYjVwUGVEQ0RRWGFxdUhldmFwN1llcHJtWFVUQ2JzdW9hWUZHOEg",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6jbhf9/_/djczsed?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6jbhf9\", \"view_count\": 2, \"secure_media_embed\": {}, \"clicked\": false, \"report_reasons\": [], \"author\": \"BJO_test_user\", \"saved\": false, \"score\": 1, \"approved_by\": \"<USERNAME>\", \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 3, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"spam\": false, \"stickied\": false, \"can_gild\": true, \"thumbnail_height\": null, \"removed\": false, \"approved\": true, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jbhf9\", \"created\": 1498378796.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbhf9/this_post_will_receive_a_notification/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"title\": \"This post will receive a notification.\", \"created_utc\": 1498349996.0, \"ups\": 1, \"media\": null, \"upvote_ratio\": 1.0, \"ignore_reports\": false, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"num_reports\": 0, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_6jbhf9\", \"likes\": null, \"replies\": {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_6jbhf9\", \"likes\": null, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"djczsnd\", \"gilded\": 0, \"archived\": false, \"score\": 1, \"report_reasons\": [], \"author\": \"BJO_test_user\", \"parent_id\": \"t1_djczsed\", \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"controversiality\": 0, \"body\": \"This comment will be removed along with its parent.\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis comment will be removed along with its parent.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"stickied\": false, \"can_gild\": true, \"removed\": false, \"approved\": false, \"score_hidden\": false, \"subreddit_type\": \"private\", \"name\": \"t1_djczsnd\", \"created\": 1498379092.0, \"subreddit\": \"ThirdRealm\", \"author_flair_text\": \"ayy .:lmao\", \"spam\": false, \"created_utc\": 1498350292.0, \"ups\": 1, \"depth\": 1, \"ignore_reports\": false, \"mod_reports\": [], \"num_reports\": 0, \"distinguished\": null}}], \"after\": null, \"before\": null}}, \"user_reports\": [], \"saved\": false, \"id\": \"djczsed\", \"gilded\": 0, \"archived\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"parent_id\": \"t3_6jbhf9\", \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"controversiality\": 0, \"body\": \"This comment will be nuked.\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis comment will be nuked.\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"stickied\": false, \"can_gild\": true, \"removed\": false, \"approved\": false, \"score_hidden\": false, \"subreddit_type\": \"private\", \"name\": \"t1_djczsed\", \"created\": 1498379081.0, \"subreddit\": \"ThirdRealm\", \"author_flair_text\": \"ayy .:lmao\", \"spam\": false, \"created_utc\": 1498350281.0, \"ups\": 1, \"depth\": 0, \"ignore_reports\": false, \"mod_reports\": [[\"n\", \"<USERNAME>\"]], \"num_reports\": 1, \"distinguished\": null}}], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "4009",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:06 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350427.795415,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426812.Z0FBQUFBQlpUd05hODU3cTQ1cEFTc3hKYmZzaWNTZDFaWXpzNVF0M0FwckQ3c3BCSThESWRuOHdUZEdra1hvdFZqWVYxOUZsRHI0dWEtdFhoT201X0ZWaEEzdXpVN0xyR2VxM1VCdlVJbVZkeE9pa00xR1Fnd3hLS2x5X1VrVG5QVVRmOXRHVTlrT2c; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:06 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "574.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "26",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=thZtt1%2FaJS9DwrSEtyIcyTCzoTgvkRR3JJMZziv4UkQtJKCbTHZHh4CM%2BiRdTRfwNkBHKBNg%2FAyXtZxbzFJA%2BPk0T5nBVe7Z",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6jbhf9/_/djczsed?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_djczsnd&spam=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "38",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426812.Z0FBQUFBQlpUd05hODU3cTQ1cEFTc3hKYmZzaWNTZDFaWXpzNVF0M0FwckQ3c3BCSThESWRuOHdUZEdra1hvdFZqWVYxOUZsRHI0dWEtdFhoT201X0ZWaEEzdXpVN0xyR2VxM1VCdlVJbVZkeE9pa00xR1Fnd3hLS2x5X1VrVG5QVVRmOXRHVTlrT2c",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:07 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350427.941695,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426956.Z0FBQUFBQlpUd05idnJZeldzYmM1djRiQ0pfTWhjTDlCenY0VWxnaFlmbXg1cGlwSlVSRFBWMHlqVUVRMWluX0RRaUdsZHhzOXVhMXdGcWFIT0pDTHJFckE4bWFHTGtJVjdQZmxzMWhCNGx5SGx1Zk5fWkk4RFNBaV8teVNYVWxUc3VtNVhfZHRicmQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:07 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "573.0",
+          "x-ratelimit-reset": "174",
+          "x-ratelimit-used": "27",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:27:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_djczsed&spam=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "38",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=ojKdrGZdbG3IxNtMHS; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd05haUdQQ3NteTZzOTF5Tk5PMGNRWTNkMTlKbjAzYi1uRG4yVHdBRGd0THZLUWt5SGdvZHRHYmNQZjBHRlZwSEdWMWo0T003Rms1MVdYOTh5N1BIZ1doZWVQUVBoZG5vaVRfeUhhNEVIbXBsQ0ZwTWRHZ1BzNGVfbjZObzRnWUdWQkM; session_tracker=klM1rjCOuBi3RchFpJ.0.1498350426956.Z0FBQUFBQlpUd05idnJZeldzYmM1djRiQ0pfTWhjTDlCenY0VWxnaFlmbXg1cGlwSlVSRFBWMHlqVUVRMWluX0RRaUdsZHhzOXVhMXdGcWFIT0pDTHJFckE4bWFHTGtJVjdQZmxzMWhCNGx5SGx1Zk5fWkk4RFNBaV8teVNYVWxUc3VtNVhfZHRicmQ",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:27:07 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498350427.095477,VS0,VE586",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=klM1rjCOuBi3RchFpJ.0.1498350427115.Z0FBQUFBQlpUd05ia2hlLU5Ccy1vdENuWkNFUFZzMUFfYmU3Mk9VbUoydzMzX0FCaU9Jb0txWUR0czhjVUVQRFFCNlNhMEJ0Nk9oa1diMlh5TGlLekpoUkdNaEQ0ZjBHdWdtRGgwOWQzaUZrcjlmUVRua3gzVWM4bWs0bXRtYW4tZ3E3WHhHSWtScjU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:27:07 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "572.0",
+          "x-ratelimit-reset": "173",
+          "x-ratelimit-used": "28",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestRemoval.system.json
+++ b/test/cassettes/TestRemoval.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestRemoval.system.json
+++ b/test/cassettes/TestRemoval.system.json
@@ -1,0 +1,397 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:23:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:56 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1730-ORD",
+          "X-Timer": "S1498350236.012323,VS0,VE473",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350236027.Z0FBQUFBQlpUd0tjUS05Qkk0aTFyNTVfNmVyTVBZeFMwWTRyd0oyZmh4elp5N3E3X0NCSXJPalVJTkpCT1dZaThucXVKdFNEMDdDdkRMZmVNSjE1Q09UdEJMa0l3dkZLM2F5WkdfVURMOENLU0gtQnZkUWVZUVF4blU2Yjh6b2M0ejRmSV93LVEtLUM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:56 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350236027.Z0FBQUFBQlpUd0tjUS05Qkk0aTFyNTVfNmVyTVBZeFMwWTRyd0oyZmh4elp5N3E3X0NCSXJPalVJTkpCT1dZaThucXVKdFNEMDdDdkRMZmVNSjE1Q09UdEJMa0l3dkZLM2F5WkdfVURMOENLU0gtQnZkUWVZUVF4blU2Yjh6b2M0ejRmSV93LVEtLUM",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:56 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350237.757570,VS0,VE54",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:23:56 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "588.0",
+          "x-ratelimit-reset": "364",
+          "x-ratelimit-used": "12",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=AY30ACsxVEfDaXJnnmKnVd2irpdX0goZu8vV1XHB%2FAqcDeL0d61sP4HfHOeXTbY%2FffAmY2%2BFVTA7gobzMHbr74BTdnEuwhzZ",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350236775.Z0FBQUFBQlpUd0tjNl9pOUQ1YlpYLWZsRFpZOG02S29xN1FzUEhHVEgyUENNVDNmNzRkNFA4NEYybHh6ZVdnVkgtUXpTbXIxcW05Q2hhMXl3T2ViSFB3bzZ2YnUzVzRtRDd6T0JhTTlLUkprdDNKVnNfZ3hZOU10ZGFEZlpESlMwU3NQUHZneGFKUVY",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 3, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 3, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:56 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350237.852847,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350236884.Z0FBQUFBQlpUd0tjdllqWjR2SjlwRkZiZG53YnpQMlpzeE15SXlHcEpKb0FCWWgwUXZIc0d0WUpDVFZVN0FtMmhVZFFRekk5QlpKMXB6c0pScl85Vzcwdy1TclJ3S2F0WEVLdElNV2pndXAwUVdmekx4elNPMnc0SFgwY3JubmExSm9OaVRPNzJ2cDk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:56 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "587.0",
+          "x-ratelimit-reset": "364",
+          "x-ratelimit-used": "13",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=jLZCksoRIDOqwvJUp7fnm3xzmveOnpeFTiXfotgiqaT9hUbOKi8TTD4LmZD6KDLwwynf%2B%2BF3yq5P0sSRWfrBeIMqdSEJIl66",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350236884.Z0FBQUFBQlpUd0tjdllqWjR2SjlwRkZiZG53YnpQMlpzeE15SXlHcEpKb0FCWWgwUXZIc0d0WUpDVFZVN0FtMmhVZFFRekk5QlpKMXB6c0pScl85Vzcwdy1TclJ3S2F0WEVLdElNV2pndXAwUVdmekx4elNPMnc0SFgwY3JubmExSm9OaVRPNzJ2cDk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:57 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350237.001974,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237019.Z0FBQUFBQlpUd0tkb2VMRVJEMExWeWxrRXR1VlhXeGFaek4xNFhHSWxENVBYVW1kb19MamtMRkJXMXVScS1kMGZDa0tkc3duSTdTTFpLZU1hZl9HU3hrbVVIeWFEZ0xEN19DUmxIdmlwc0k5ck9iSDRnc3BIemJDS2cyWGhLN1dKWlJxNmp6VTFWTEk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:57 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "586.0",
+          "x-ratelimit-reset": "363",
+          "x-ratelimit-used": "14",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=SFGGAZ5RPfOtkQQQEK%2FkFumN0GMnqBWvjmeN37pLmkGvrZXWBlfViuF2z%2BGe3%2BXUtL%2FhKmCjiuxJjOJT4em0Jtw1TmyTAyq1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237019.Z0FBQUFBQlpUd0tkb2VMRVJEMExWeWxrRXR1VlhXeGFaek4xNFhHSWxENVBYVW1kb19MamtMRkJXMXVScS1kMGZDa0tkc3duSTdTTFpLZU1hZl9HU3hrbVVIeWFEZ0xEN19DUmxIdmlwc0k5ck9iSDRnc3BIemJDS2cyWGhLN1dKWlJxNmp6VTFWTEk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"6jbhy0\", \"view_count\": 1, \"secure_media_embed\": {}, \"clicked\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"link_flair_text\": null, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"title\": \"This post will be removed.\", \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"can_gild\": true, \"is_self\": true, \"removed\": false, \"approved\": false, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jbhy0/this_post_will_be_removed/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jbhy0\", \"created\": 1498378979.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jbhy0/this_post_will_be_removed/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498350179.0, \"ups\": 1, \"media\": null, \"ignore_reports\": false, \"mod_reports\": [[\"r\", \"<USERNAME>\"]], \"visited\": false, \"num_reports\": 1, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1633",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:57 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350237.140923,VS0,VE171",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237158.Z0FBQUFBQlpUd0tkOGctR1oydFBVWktSbXhxMUhBOGVKOVVkb1hBWHEzM0N3bEd6dU52Y2UwYnpka3BzYVBQYl9nWXEwNDg1ZUlRQTRfcTgzR3VLRDVSVXNtMHpyVl85OWE2QzBFdGdKSE5KdEx6di1WcEhjUEtZNzRza3U3TnhUbDFIdzFBOWtXWWI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:57 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "585.0",
+          "x-ratelimit-reset": "363",
+          "x-ratelimit-used": "15",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=w1COGXU2V1Ak%2Bxh9vY%2Bs%2BZNpCw6o9glTUPWtatPsbbtffBC9IuyCCJTeedLq1iylDsbrnnWTGrZ0BxC4snWpzzIWkvTD5A%2B7",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbhy0&spam=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "37",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237158.Z0FBQUFBQlpUd0tkOGctR1oydFBVWktSbXhxMUhBOGVKOVVkb1hBWHEzM0N3bEd6dU52Y2UwYnpka3BzYVBQYl9nWXEwNDg1ZUlRQTRfcTgzR3VLRDVSVXNtMHpyVl85OWE2QzBFdGdKSE5KdEx6di1WcEhjUEtZNzRza3U3TnhUbDFIdzFBOWtXWWI",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:57 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350237.361635,VS0,VE140",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237377.Z0FBQUFBQlpUd0tkZmV2ZENMNE11eXRFMkJqTXlZbmVZT2dyWUFYYWpvWnUwQWE5MlFzY05ETDE0Ukx0c3VEemd5UGRmZy1DWTBVeUdtdDBhUDNQT2FlOThKOExTUlhYZkpwRDV5R3lLTEZtVmwtRWRYUEkzTGdTT1pQdjRsNDVCX2dlUC1oRnUzVWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:57 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "584.0",
+          "x-ratelimit-reset": "363",
+          "x-ratelimit-used": "16",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:23:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jbhy0"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "26",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=h2DurPMJp6qNtqimbw; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd0tjVjhtWEs5ODVORHdSemI1RDRNYlJQei1SaDRrUDd1MnRjNkg4UklLXzAyaWFZc2l0aDNVdHhWb2FHT3FHeFhTQTFnVGM1RXM3RXl1cG1oZjJsN1pDZUxjOF9aRVNaUnhnU0NTSlhlYzlkZjB1S2VwZF9oLWlNbGd0TTJDVnlrY1E; session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237377.Z0FBQUFBQlpUd0tkZmV2ZENMNE11eXRFMkJqTXlZbmVZT2dyWUFYYWpvWnUwQWE5MlFzY05ETDE0Ukx0c3VEemd5UGRmZy1DWTBVeUdtdDBhUDNQT2FlOThKOExTUlhYZkpwRDV5R3lLTEZtVmwtRWRYUEkzTGdTT1pQdjRsNDVCX2dlUC1oRnUzVWk",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/lock/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:23:57 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1723-ORD",
+          "X-Timer": "S1498350238.542438,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=vRnHAoRxbZpVxwGs6u.0.1498350237559.Z0FBQUFBQlpUd0tkX2tER1RzSHQzSlc2ZEJ4aGs0bHVmZFAzeVlrUkhTclZrSkdKUFY0TTJQa1dlbVE2aXE0M3NjdWpacmx4dmxZVmF1REFSVDJMaW9CU3NjRTRicjUwVTJYMHZvLXZ0QmMtYmFTRUlOU1I4VFhkVVJpMDlodEJaZTVZVlNNWXhTc2Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:23:57 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "583.0",
+          "x-ratelimit-reset": "363",
+          "x-ratelimit-used": "17",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/lock/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/cassettes/TestUsernote.system.json
+++ b/test/cassettes/TestUsernote.system.json
@@ -181,7 +181,7 @@
           "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       },
       "response": {
         "body": {
@@ -218,7 +218,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?raw_json=1"
       }
     },
     {

--- a/test/cassettes/TestUsernote.system.json
+++ b/test/cassettes/TestUsernote.system.json
@@ -1,0 +1,511 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:14 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1738-ORD",
+          "X-Timer": "S1498351755.521151,VS0,VE329",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351754538.Z0FBQUFBQlpUd2lLVHJiSGxTbElyZnFGdzhMc294Q3JoOGw1akNyQk9HRnJ4NGhXX0lCZGxIanVEMTNoLUdBQThxQWlSQTBZMXNjUkpxNjFxVnhZelJqZlZQVmN0bldIWl9USHJCbE5iRDVpSng0cWRPQUdqSnhfWnpIb3JXbTZ3VFA2TmdhLTFXdGc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:14 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; session_tracker=myRHWWv51HCUZyzmlk.0.1498351754538.Z0FBQUFBQlpUd2lLVHJiSGxTbElyZnFGdzhMc294Q3JoOGw1akNyQk9HRnJ4NGhXX0lCZGxIanVEMTNoLUdBQThxQWlSQTBZMXNjUkpxNjFxVnhZelJqZlZQVmN0bldIWl9USHJCbE5iRDVpSng0cWRPQUdqSnhfWnpIb3JXbTZ3VFA2TmdhLTFXdGc",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"rules\": [{\"kind\": \"all\", \"description\": \"foobar\", \"short_name\": \"blah blah blah\", \"violation_reason\": \"bazinga\", \"created_utc\": 1453790512.0, \"priority\": 0, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Efoobar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"comment\", \"description\": \"bar\", \"short_name\": \"foo\", \"violation_reason\": \"foo\", \"created_utc\": 1465781914.0, \"priority\": 1, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ebar\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}, {\"kind\": \"all\", \"description\": \"It has some **markdown**.\", \"short_name\": \"This is a sample rule.\", \"violation_reason\": \"This is a sample rule.\", \"created_utc\": 1479179608.0, \"priority\": 2, \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EIt has some \\u003Cstrong\\u003Emarkdown\\u003C/strong\\u003E.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\"}], \"site_rules\": [\"Spam\", \"Personal and confidential information\", \"Threatening, harassing, or inciting violence\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1104",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351755.055899,VS0,VE55",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jun-2019 00:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=uLdXKAcu2X4lqcskTpGuzcTBUnyPmRJqot99PNwbI59qeBM1ed7SoqnKZYeg63BbnZCt5t%2FXulCEhj9ozT%2BPBtHaj%2BN3k2u4",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/rules?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755080.Z0FBQUFBQlpUd2lMUE1LQ0wycnl5N2k0eHZkNWhoMmE1eFRJSC1vZ3VpZTBoV2Jwejc0bFVRalB2YXVwSjF5LWhBdXRDeUVfZk95NHFORy1POEQ1ZmFIaWs1M0p2ZkhwNHk2bEl0c2w0dEtLNjZUbFVqaHJhYXNqelVpcFFzTHNHWXJPZTRBaTNiSHQ",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_is_contributor\": true, \"banner_img\": \"\", \"submit_text_html\": null, \"user_is_banned\": false, \"wiki_enabled\": true, \"show_media\": false, \"id\": \"390u2\", \"description\": \"\", \"submit_text\": \"\", \"display_name\": \"ThirdRealm\", \"header_img\": null, \"description_html\": null, \"title\": \"Frege's platonic heaven\", \"collapse_deleted_comments\": false, \"public_description\": \"\", \"over18\": false, \"public_description_html\": null, \"spoilers_enabled\": true, \"icon_size\": null, \"suggested_comment_sort\": null, \"active_user_count\": 2, \"icon_img\": \"\", \"header_title\": null, \"display_name_prefixed\": \"r/ThirdRealm\", \"user_is_muted\": false, \"submit_link_label\": null, \"accounts_active\": 2, \"public_traffic\": false, \"header_size\": null, \"subscribers\": 1, \"submit_text_label\": null, \"key_color\": \"\", \"lang\": \"en\", \"whitelist_status\": null, \"name\": \"t5_390u2\", \"created\": 1436378089.0, \"url\": \"/r/ThirdRealm/\", \"quarantine\": false, \"hide_ads\": false, \"created_utc\": 1436349289.0, \"banner_size\": null, \"user_is_moderator\": true, \"accounts_active_is_fuzzed\": false, \"advertiser_category\": null, \"user_sr_theme_enabled\": true, \"allow_images\": true, \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"private\", \"submission_type\": \"any\", \"user_is_subscriber\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1290",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351755.165266,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755182.Z0FBQUFBQlpUd2lMWjZ1eGJvRE1id2F0UVBWR3g5Z3lzbVd2UGxId2ZaTV9MQThYUVVzaTUwTlBxLUptMFVrYXNRNTEzNDZEb0pwTWdodjdtaWUzc3c1ZmQxZEtUdThyWG1fekloU241WmtoNWFtTWs2ZjlTbFJ2NG1WNkx3N19od0xtT08zOF9zemQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=Rhl4D0KvZwVdnWTZ20k9uODDQXCZCEDP741WPfqSR%2F8PW5PDo2MF5820SqZtwa6Haz%2BLP5vpPh7yvHOxqI84iYTR0qEFtie2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/thirdrealm/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755182.Z0FBQUFBQlpUd2lMWjZ1eGJvRE1id2F0UVBWR3g5Z3lzbVd2UGxId2ZaTV9MQThYUVVzaTUwTlBxLUptMFVrYXNRNTEzNDZEb0pwTWdodjdtaWUzc3c1ZmQxZEtUdThyWG1fekloU241WmtoNWFtTWs2ZjlTbFJ2NG1WNkx3N19od0xtT08zOF9zemQ",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1436349289.0, \"id\": \"t2_3221r\", \"name\": \"TheGrammarBolshevik\"}, {\"author_flair_css_class\": \"\", \"author_flair_text\": \"ayy lmao\", \"mod_permissions\": [\"all\"], \"date\": 1465092773.0, \"id\": \"t2_xw27h\", \"name\": \"<USERNAME>\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1485809791.0, \"id\": \"t2_nmqzc\", \"name\": \"BernardJOrtcutt\"}, {\"author_flair_css_class\": null, \"author_flair_text\": null, \"mod_permissions\": [\"all\"], \"date\": 1497831441.0, \"id\": \"t2_16r83m\", \"name\": \"L72_Elite_Kraken\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351755.267737,VS0,VE63",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755285.Z0FBQUFBQlpUd2lMT21heWxpSXNlakpveWt0V1F2YmplZDk1Z1RmUzc5a19IM0NKbXhPbVVuOXEyY3p5SmVTTWZLQkF0NmJkQXVkdGdrNTkzYTdHVldmQndnSGd1NUk2MW54ZElBTXVhanFWYW55M0N3bmN6X3hyWjVoX2V3ZC1sd0VjUU9rWndMRlg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=WapwOmaOemdfN947WYqoBLWU1T4syy9CJ0CDP6%2FzYPnTUJzm%2BtGuUOraBGttgJF7OLLh0%2Fud2z5LOJKsiZAxs0mBTL0MBhpA",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/moderators/?unique=0&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755285.Z0FBQUFBQlpUd2lMT21heWxpSXNlakpveWt0V1F2YmplZDk1Z1RmUzc5a19IM0NKbXhPbVVuOXEyY3p5SmVTTWZLQkF0NmJkQXVkdGdrNTkzYTdHVldmQndnSGd1NUk2MW54ZElBTXVhanFWYW55M0N3bmN6X3hyWjVoX2V3ZC1sd0VjUU9rWndMRlg",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"contest_mode\": false, \"banned_by\": null, \"media_embed\": {}, \"subreddit\": \"ThirdRealm\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"saved\": false, \"id\": \"6jblsw\", \"view_count\": 1, \"secure_media_embed\": {}, \"clicked\": false, \"score\": 1, \"report_reasons\": [\"This attribute is deprecated. Please use mod_reports and user_reports instead.\"], \"author\": \"BJO_test_user\", \"link_flair_text\": null, \"subreddit_name_prefixed\": \"r/ThirdRealm\", \"approved_by\": null, \"over_18\": false, \"domain\": \"self.ThirdRealm\", \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"\", \"subreddit_id\": \"t5_390u2\", \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": \"\", \"gilded\": 0, \"title\": \"This post will result in a usernote.\", \"downs\": 0, \"brand_safe\": false, \"archived\": false, \"removal_reason\": null, \"stickied\": false, \"can_gild\": true, \"is_self\": true, \"removed\": false, \"approved\": false, \"hide_score\": false, \"spoiler\": false, \"permalink\": \"/r/ThirdRealm/comments/6jblsw/this_post_will_result_in_a_usernote/\", \"subreddit_type\": \"private\", \"locked\": false, \"name\": \"t3_6jblsw\", \"created\": 1498380414.0, \"url\": \"https://www.reddit.com/r/ThirdRealm/comments/6jblsw/this_post_will_result_in_a_usernote/\", \"author_flair_text\": \"ayy .:lmao\", \"quarantine\": false, \"spam\": false, \"created_utc\": 1498351614.0, \"ups\": 1, \"media\": null, \"ignore_reports\": false, \"mod_reports\": [[\"n\", \"<USERNAME>\"]], \"visited\": false, \"num_reports\": 1, \"is_video\": false, \"distinguished\": null}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1663",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351755.376069,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755409.Z0FBQUFBQlpUd2lMNHNZUUZVbGpPVm5QZXEtSlREV2pWVWZtM2tEVUgySGNySkVXd3MzQzVLX2p2cWlHQmhfTm1OVnJ4Z25xWFNnbVVWQzk5MmtJYVVMcHd4ZXdsSGVzMjVJZ2JzS2xpOWllZGh1NmFXTEhtVUJrV0I5Y0FUWklrU3YwamxnREhFSmw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "4",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=yhCiQSHq%2BKDWoPu8xlFR5yumgeg0qQu%2BYGYNGUl%2FxWm1jnuDATDEUMrlSvKhzfF4T3yzUN4c3B%2BFpOJoHzztugKdnoHycTEp",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/about/reports/?limit=1024&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_6jblsw"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "26",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755409.Z0FBQUFBQlpUd2lMNHNZUUZVbGpPVm5QZXEtSlREV2pWVWZtM2tEVUgySGNySkVXd3MzQzVLX2p2cWlHQmhfTm1OVnJ4Z25xWFNnbVVWQzk5MmtJYVVMcHd4ZXdsSGVzMjVJZ2JzS2xpOWllZGh1NmFXTEhtVUJrV0I5Y0FUWklrU3YwamxnREhFSmw",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351756.512762,VS0,VE93",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755532.Z0FBQUFBQlpUd2lMR2tabVc5Uno2TmQ0elM5OFE2QnMtVzlXMi1oVXNmUk5SRkVUX0ZsTG9DQWIxb3VNRThub1M1clY3enpMT2l1bmMzdEpKX0VsZjZRS1I2RGpDcVlULXZxaDh2LTZNeHRyZ1hRbm9UWnl0c0dGbWptR3lUR3B1eGw1dFZJb1VyR2g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/approve/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755532.Z0FBQUFBQlpUd2lMR2tabVc5Uno2TmQ0elM5OFE2QnMtVzlXMi1oVXNmUk5SRkVUX0ZsTG9DQWIxb3VNRThub1M1clY3enpMT2l1bmMzdEpKX0VsZjZRS1I2RGpDcVlULXZxaDh2LTZNeHRyZ1hRbm9UWnl0c0dGbWptR3lUR3B1eGw1dFZJb1VyR2g",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/wiki/revisions/usernotes?limit=1&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"timestamp\": 1498284566.0, \"reason\": null, \"author\": {\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"do_not_track\": true, \"show_amp_link\": true, \"live_happening_now\": true, \"adserver_reporting\": true, \"give_hsts_grants\": true, \"legacy_search_pref\": true, \"listing_service_rampup\": true, \"mobile_web_targeting\": true, \"default_srs_holdout\": {\"owner\": \"relevance\", \"variant\": \"popular\", \"experiment_id\": 171}, \"adzerk_do_not_track\": true, \"users_listing\": true, \"show_user_sr_name\": true, \"whitelisted_pms\": true, \"sticky_comments\": true, \"upgrade_cookies\": true, \"ads_prefs\": true, \"block_user_by_report\": true, \"ads_auto_refund\": true, \"orangereds_as_emails\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"expando_events\": true, \"eu_cookie_policy\": true, \"utm_comment_links\": true, \"force_https\": true, \"mobile_native_banner\": true, \"post_to_profile_beta\": true, \"reddituploads_redirect\": true, \"outbound_clicktracking\": true, \"new_loggedin_cache_policy\": true, \"inbox_push\": true, \"scroll_events\": true, \"https_redirect\": true, \"search_dark_traffic\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"pause_ads\": true, \"programmatic_ads\": true, \"geopopular\": true, \"show_recommended_link\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"ads_auction\": true, \"screenview_events\": true, \"new_report_dialog\": true, \"moat_tracking\": true, \"subreddit_rules\": true, \"mobile_settings\": true, \"adzerk_reporting_2\": true, \"activity_service_write\": true, \"ads_auto_extend\": true, \"interest_targeting\": true, \"post_embed\": true, \"new_ads_styles\": {\"owner\": \"cheddar\", \"variant\": \"control_1\", \"experiment_id\": 27}, \"geopopular_gb\": {\"owner\": \"relevance\", \"variant\": \"control_2\", \"experiment_id\": 196}, \"adblock_test\": true, \"activity_service_read\": true}, \"is_friend\": false, \"pref_no_profanity\": true, \"is_suspended\": false, \"subreddit\": null, \"is_sponsor\": false, \"gold_expiration\": null, \"id\": \"xw27h\", \"suspension_expiration_utc\": null, \"verified\": false, \"new_modmail_exists\": false, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": true, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 14, \"inbox_count\": 0, \"pref_top_karma_subreddits\": null, \"has_mail\": false, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"created\": 1463125978.0, \"gold_creddits\": 0, \"created_utc\": 1463097178.0, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true}}, \"page\": \"usernotes\", \"id\": \"9eec49ca-5860-11e7-8833-0e7962f3fb5e\"}], \"after\": \"WikiRevision_9eec49ca-5860-11e7-8833-0e7962f3fb5e\", \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2664",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351756.644747,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755678.Z0FBQUFBQlpUd2lMcXZ2Rk9MZGdVUFRGYlE3VnhaNEZuSzlVX1hjR051Qzd4aDVuc0dXRDZPRHRiZ2dWUjZ4WmlNOWJvWFV0SXN1YUZ2cnI1eC1peTVNWkludDh1RjU5OUYyTG9vZVBMSDJTLW9UcjFjUGNMdXVQaV9yNHhZR3dzX1hmVTlTVS1ZMmI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "6",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=tmfZrfXN17fjRmR0TJmM6lYADCtTltc18gMNuw8%2BbcSTC07HHRcY9DQt2DoVOfwxsMzsJfYCpMRwjThGSmF54OP02hGjdPjV",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/wiki/revisions/usernotes?limit=1&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755678.Z0FBQUFBQlpUd2lMcXZ2Rk9MZGdVUFRGYlE3VnhaNEZuSzlVX1hjR051Qzd4aDVuc0dXRDZPRHRiZ2dWUjZ4WmlNOWJvWFV0SXN1YUZ2cnI1eC1peTVNWkludDh1RjU5OUYyTG9vZVBMSDJTLW9UcjFjUGNMdXVQaV9yNHhZR3dzX1hmVTlTVS1ZMmI",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/wiki/usernotes?v=9eec49ca-5860-11e7-8833-0e7962f3fb5e&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"wikipage\", \"data\": {\"may_revise\": true, \"revision_date\": 1498284566.0, \"content_html\": \"\", \"revision_by\": {\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"features\": {\"do_not_track\": true, \"show_amp_link\": true, \"live_happening_now\": true, \"adserver_reporting\": true, \"give_hsts_grants\": true, \"legacy_search_pref\": true, \"listing_service_rampup\": true, \"mobile_web_targeting\": true, \"default_srs_holdout\": {\"owner\": \"relevance\", \"variant\": \"popular\", \"experiment_id\": 171}, \"adzerk_do_not_track\": true, \"users_listing\": true, \"show_user_sr_name\": true, \"whitelisted_pms\": true, \"sticky_comments\": true, \"upgrade_cookies\": true, \"ads_prefs\": true, \"block_user_by_report\": true, \"ads_auto_refund\": true, \"orangereds_as_emails\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"expando_events\": true, \"eu_cookie_policy\": true, \"utm_comment_links\": true, \"force_https\": true, \"mobile_native_banner\": true, \"post_to_profile_beta\": true, \"reddituploads_redirect\": true, \"outbound_clicktracking\": true, \"new_loggedin_cache_policy\": true, \"inbox_push\": true, \"scroll_events\": true, \"https_redirect\": true, \"search_dark_traffic\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"pause_ads\": true, \"programmatic_ads\": true, \"geopopular\": true, \"show_recommended_link\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"ads_auction\": true, \"screenview_events\": true, \"new_report_dialog\": true, \"moat_tracking\": true, \"subreddit_rules\": true, \"mobile_settings\": true, \"adzerk_reporting_2\": true, \"activity_service_write\": true, \"ads_auto_extend\": true, \"interest_targeting\": true, \"post_embed\": true, \"new_ads_styles\": {\"owner\": \"cheddar\", \"variant\": \"control_1\", \"experiment_id\": 27}, \"geopopular_gb\": {\"owner\": \"relevance\", \"variant\": \"control_2\", \"experiment_id\": 196}, \"adblock_test\": true, \"activity_service_read\": true}, \"is_friend\": false, \"pref_no_profanity\": true, \"is_suspended\": false, \"subreddit\": null, \"is_sponsor\": false, \"gold_expiration\": null, \"id\": \"xw27h\", \"suspension_expiration_utc\": null, \"verified\": false, \"new_modmail_exists\": false, \"over_18\": false, \"is_gold\": false, \"is_mod\": true, \"has_verified_email\": true, \"has_mod_mail\": false, \"hide_from_robots\": false, \"modhash\": null, \"link_karma\": 14, \"inbox_count\": 0, \"pref_top_karma_subreddits\": null, \"has_mail\": false, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"created\": 1463125978.0, \"gold_creddits\": 0, \"created_utc\": 1463097178.0, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true}}, \"content_md\": \"{\\\"ver\\\": 6, \\\"constants\\\": {\\\"users\\\": [\\\"TheGrammarBolshevik\\\", \\\"<USERNAME>\\\"], \\\"warnings\\\": [null, \\\"abusewarn\\\"]}, \\\"blob\\\": \\\"eJyNz70KwjAUBeBXCZkUOiRtkqaOji5KV5EiGNHSNjY/Fix5dxOx2CFgpwP3nvvBHeF2t6+M0KayWii4ASPstI+jTx+wFK18igtY9daX7rJbwwRA41eYFDylNGepH7Rh4LMJN03CanKtH6E5hIVLwEIOI05iXPZKVYQ7SG2AmszSNgLgmch5hjPC2VdEP5EOPTMiIp47aW5CzQxWUJQXKGKYnjI7GWjZkx+O8fwfh93JuTeLaWpt\\\"}\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2920",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351756.793188,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755809.Z0FBQUFBQlpUd2lMTkdudXNrcldhQWJ2QVhKVERpbUhzS29kOXVVOXhOdkpIR1lHZUdCNmszVDZSbzI4VFpJcmdGUUp6cVZnXzBvYmNWdmlRQ2JWeU1zV0N3TEsyMnhqdVJSc0ZuWVoxeE4tVnpEN3RlWlR2WlFyMkwyQ1FuMDZlaG53Y3ptYWZVOF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:15 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "7",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=bpvAht0y4ChFiXvHjt5jkPDmo0bL5mWhm%2FJKUy%2F7qP%2FSHQmHyiGANiZCkgw16RAaA0S%2B90S9AV4sfDgD8q8qkxfj7h5J3%2BHB",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/wiki/usernotes?v=9eec49ca-5860-11e7-8833-0e7962f3fb5e&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-25T00:49:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&content=%7B%22ver%22%3A+6%2C+%22constants%22%3A+%7B%22users%22%3A+%5B%22TheGrammarBolshevik%22%2C+%22<USERNAME>%22%5D%2C+%22warnings%22%3A+%5Bnull%2C+%22abusewarn%22%5D%7D%2C+%22blob%22%3A+%22eJyd0EFvgyAYBuC%2F8oVL18QDqCDu2OMuW7w2TdN231INSgXUZI3%2FvdjU1ANJl53e5AUePriSzcfn3qF1%2B86iIe9wJY31sfXpg2xQldijBXdGOOnmhBcHq7M2FldQWjjMJYmAOH%2BCpblMOMs490U9FT7VRKlIVEdlh2nnMC2METxuKbDWPX7DW9v5UUrdrJdczHkm4hCX%2FlSXf3CMyjTEJb%2BxCXBf2jows1l0CoEtRCkTlqRSPET6FPnQCocB8dBo%2F59mYYic0yynAcO1XHSzQf%2F2yDsnZPaKY%2BNuHG8YoobH%22%7D&page=usernotes&previous=9eec49ca-5860-11e7-8833-0e7962f3fb5e"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "593",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=tcfLm3DAX9yNpvfPAC; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpUd2lMNHVRNEZMVFQ0RzZQN1dody0xemEyRDVkMGQ5NWZURXg3TU44c3dxVlpGOW40ZGlPYWJUOHFvRDdjaW9rc08wWVhSSFc2c2ZpRVh3cXJneGFqX2EyVTRtaVROcHcwS2FFSzQ5d1BkcGlTSWpzLXVZNy1kQ0VRU2RiUldmTlBKbEI; session_tracker=myRHWWv51HCUZyzmlk.0.1498351755809.Z0FBQUFBQlpUd2lMTkdudXNrcldhQWJ2QVhKVERpbUhzS29kOXVVOXhOdkpIR1lHZUdCNmszVDZSbzI4VFpJcmdGUUp6cVZnXzBvYmNWdmlRQ2JWeU1zV0N3TEsyMnhqdVJSc0ZuWVoxeE4tVnpEN3RlWlR2WlFyMkwyQ1FuMDZlaG53Y3ptYWZVOF8",
+          "User-Agent": "Tests for BernardJOrtcutt - levimroth@gmail.com PRAW/4.5.1 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/ThirdRealm/api/wiki/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 25 Jun 2017 00:49:16 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1747-ORD",
+          "X-Timer": "S1498351756.967480,VS0,VE99",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=myRHWWv51HCUZyzmlk.0.1498351755989.Z0FBQUFBQlpUd2lNQklZZDZiQ3hCNFluLUFYc3EzWmx4V2hyYXpYOGZVdlVyRUxZS3BlaE1IQWZvc2lIMHZPSXBxLXozbXRCNWdMdmI2Z0xaNTNEd3h5SktNVU9XMnlSdUM1WjBIRHVaTmk2bnROd2lXQ3Qzbm1BSVdpTW1hOXk2RjZ3Mm1UT3RCSDg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 25-Jun-2017 02:49:16 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "592.0",
+          "x-ratelimit-reset": "45",
+          "x-ratelimit-used": "8",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/ThirdRealm/api/wiki/edit/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/test/configs/AutomodWatcherConfig.yaml
+++ b/test/configs/AutomodWatcherConfig.yaml
@@ -1,0 +1,14 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Watched"
+    details: "Suspected of being a spy"
+    trigger: [watch]
+    types: [post, comment]
+    remove: false
+    actions:
+      - action: wikiwatch
+        params:
+          placeholder: 'do!not!remove!watchlist'

--- a/test/configs/BannerConfig.yaml
+++ b/test/configs/BannerConfig.yaml
@@ -1,0 +1,18 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Banned"
+    details: "Testing"
+    trigger: [b]
+    types: [post, comment]
+    remove: true
+    actions:
+    - action: ban
+      params:
+        message: |
+          Psychologism is looked upon with suspicion in /r/ThirdRealm. Take a
+          few days to reconsider your ontological commitments.
+        reason: "psychologism"
+        duration: 3

--- a/test/configs/NotifierConfig.yaml
+++ b/test/configs/NotifierConfig.yaml
@@ -1,0 +1,14 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Comment rule warning"
+    details: "Testing"
+    trigger: [w]
+    types: [post]
+    remove: false
+    actions:
+    - action: notify
+      params:
+        text: "Please keep our rules in mind!"

--- a/test/configs/NukerConfig.yaml
+++ b/test/configs/NukerConfig.yaml
@@ -1,0 +1,12 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Nuke comment thread"
+    details: "Testing"
+    trigger: [n]
+    types: [comment]
+    remove: true
+    actions:
+    - action: nuke

--- a/test/configs/RemovalConfig.yaml
+++ b/test/configs/RemovalConfig.yaml
@@ -1,0 +1,10 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Removed"
+    details: "Testing"
+    trigger: [r]
+    types: [post, comment]
+    remove: true

--- a/test/configs/UsernoteConfig.yaml
+++ b/test/configs/UsernoteConfig.yaml
@@ -1,0 +1,15 @@
+subreddits:
+- name: thirdrealm
+  default_post_actions: false
+  default_comment_actions: false
+  rules:
+  - name: "Usernote added"
+    details: "Testing"
+    trigger: [n]
+    types: [post, comment]
+    remove: false
+    actions:
+    - action: usernote
+      params:
+        text: "Believes the concept 'horse' is a concept"
+        level: "abusewarn"

--- a/test/helper.py
+++ b/test/helper.py
@@ -60,9 +60,8 @@ class BJOTest(unittest.TestCase):
         self.db.row_factory = sqlite3.Row
         self.cur = self.db.cursor()
         with open('create_tables.sql') as f:
-            commands = f.read().split(';')
-            for command in commands:
-                self.cur.execute(command)
+            command = f.read()
+        self.db.executescript(command)
 
     def betamax_configure(self):
         http = self.r._core._requestor._http

--- a/test/helper.py
+++ b/test/helper.py
@@ -11,11 +11,7 @@ import sys
 sys.path.append('bernard/')
 
 
-def _sleep(*args):
-    raise Exception('Call to sleep')
-
-
-time.sleep = _sleep
+time.sleep = lambda _: None
 
 
 def b64_string(input_string):
@@ -61,6 +57,7 @@ class BJOTest(unittest.TestCase):
 
         self.subreddit = self.r.subreddit('thirdrealm')
         self.db = sqlite3.connect(':memory:')
+        self.db.row_factory = sqlite3.Row
         self.cur = self.db.cursor()
         with open('create_tables.sql') as f:
             commands = f.read().split(';')

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -2,7 +2,6 @@ import praw
 import re
 from .helper import BJOTest
 from bernard import actors
-from mock import patch
 
 
 class TestActor(BJOTest):
@@ -31,8 +30,7 @@ class TestActor(BJOTest):
                 'TestActor.test_match__incorrect_type'):
             self.assertFalse(self.actor.match('foo', post))
 
-    @patch('time.sleep', return_value=None)
-    def test_parse(self, _):
+    def test_parse(self):
         post = self.r.submission(id='5e7w80')
         with self.recorder.use_cassette('TestActor.test_parse'):
             self.actor.parse('foo', 'TGB', post)
@@ -50,8 +48,7 @@ class TestActor(BJOTest):
 
 
 class TestBanner(BJOTest):
-    @patch('time.sleep', return_value=None)
-    def test_action(self, _):
+    def test_action(self):
         actor = actors.Banner("You banned", "testing purposes", 4, self.db,
                               self.subreddit)
         post = self.r.submission(id='5e7wc7')
@@ -61,8 +58,7 @@ class TestBanner(BJOTest):
 
 
 class TestNotifier(BJOTest):
-    @patch('time.sleep', return_value=None)
-    def test_action(self, _):
+    def test_action(self):
         actor = actors.Notifier("sample_text", self.db, self.subreddit)
         post = self.r.submission(id='5kgajm')
         with self.recorder.use_cassette('TestNotifier.test_action'):
@@ -73,8 +69,7 @@ class TestNotifier(BJOTest):
 
 
 class TestNuker(BJOTest):
-    @patch('time.sleep', return_value=None)
-    def test_action(self, _):
+    def test_action(self):
         actor = actors.Nuker(self.db, self.subreddit)
         post = self.r.comment(id='dbnpgmz')
         with self.recorder.use_cassette('TestNuker.test_action'):
@@ -93,8 +88,7 @@ class TestWikiWatcher(BJOTest):
             self.assertEqual(1, len(actor.to_add))
             self.assertEqual('BJO_test_mod', actor.to_add[0])
 
-    @patch('time.sleep', return_value=None)
-    def test_after(self, _):
+    def test_after(self):
         actor = actors.WikiWatcher('test!placeholder', self.db, self.subreddit)
         actor.to_add.append('BJO_test_mod')
         with self.recorder.use_cassette('TestWikiWatcher.test_after'):

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -16,8 +16,7 @@ class TestActor(BJOTest):
             action_name="Remove",
             action_details=None,
             database=self.db,
-            subreddit=self.subreddit
-        )
+            subreddit=self.subreddit)
 
     def test_match__correct_type(self):
         post = self.r.submission(id='5e7x7o')
@@ -40,11 +39,11 @@ class TestActor(BJOTest):
             post_id = int('5e7w80', base=36)
             self.cur.execute('SELECT action_summary, id FROM actions '
                              'WHERE target_type = 3 AND target_id = ?',
-                             (post_id,))
+                             (post_id, ))
             summary, action_id = self.cur.fetchone()
             self.assertEqual('Remove', summary)
             self.cur.execute('SELECT * FROM removals WHERE action_id = ?',
-                             (action_id,))
+                             (action_id, ))
 
 
 class TestBanner(BJOTest):
@@ -81,19 +80,12 @@ class TestNuker(BJOTest):
 
 class TestWikiWatcher(BJOTest):
     def test_action(self):
-        actor = actors.WikiWatcher('test-placeholder', self.db, self.subreddit)
+        ledger = actors.WikiWatcherLedger(self.subreddit)
+        actor = actors.WikiWatcher('test-placeholder', ledger, self.db,
+                                   self.subreddit)
         post = self.r.comment(id='dbnpgmz')
         with self.recorder.use_cassette('TestWikiWatcher.test_action'):
             actor.action(post, 'TGB', action_id=1)
-            self.assertEqual(1, len(actor.to_add))
-            self.assertEqual('BJO_test_mod', actor.to_add[0])
-
-    def test_after(self):
-        actor = actors.WikiWatcher('test!placeholder', self.db, self.subreddit)
-        actor.to_add.append('BJO_test_mod')
-        with self.recorder.use_cassette('TestWikiWatcher.test_after'):
-            actor.after()
-            automod_config = self.subreddit.wiki['config/automoderator']
-            first_line = automod_config.content_md.splitlines()[0].strip()
-            self.assertEqual('author: [test!placeholder, BJO_test_mod,]',
-                             first_line)
+            placeholder_buffer = ledger.placeholder_dict['test-placeholder']
+            self.assertEqual(1,
+                             len(placeholder_buffer))

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -17,9 +17,9 @@ class TestBrowser(BJOTest):
             action_name="Remove",
             action_details=None,
             database=self.db,
-            subreddit=self.subreddit
-        )
-        self.browser = browser.Browser([self.actor], self.subreddit, self.db)
+            subreddit=self.subreddit)
+        self.browser = browser.Browser([self.actor], [], self.subreddit,
+                                       self.db)
 
     def test_run(self):
         with self.recorder.use_cassette('TestBrowser.test_run'):

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -21,8 +21,7 @@ class TestBrowser(BJOTest):
         )
         self.browser = browser.Browser([self.actor], self.subreddit, self.db)
 
-    @unittest.mock.patch('time.sleep', return_value=None)
-    def test_run(self, _):
+    def test_run(self):
         with self.recorder.use_cassette('TestBrowser.test_run'):
             self.browser.run()
             self.assertTrue(self.subactor.action.called)

--- a/test/test_system.py
+++ b/test/test_system.py
@@ -1,0 +1,40 @@
+import pytest
+
+from bernard.loader import YAMLLoader
+
+from .helper import BJOTest
+
+pytestmark = pytest.mark.system
+
+
+class SystemTest(BJOTest):
+    def basic_test(self, test_name):
+        loader = YAMLLoader(self.db, self.r)
+        with self.recorder.use_cassette(
+                'Test{}.system'.format(test_name)):
+            browsers = loader.load(
+                './test/configs/{}Config.yaml'.format(test_name))
+            browsers[0].run()
+        rows = self.db.execute('SELECT * FROM actions').fetchall()
+        assert len(rows) == 1
+
+    def test_automod_watcher(self):
+        self.basic_test('AutomodWatcher')
+
+    def test_banner(self):
+        self.basic_test('Banner')
+
+    def test_notifier(self):
+        self.basic_test('Notifier')
+        notification_count = self.db.execute(
+            'SELECT COUNT() FROM notifications').fetchall()[0][0]
+        assert notification_count == 1
+
+    def test_nuker(self):
+        self.basic_test('Nuker')
+
+    def test_removal(self):
+        self.basic_test('Removal')
+
+    def test_usernote(self):
+        self.basic_test('Usernote')


### PR DESCRIPTION
Currently, actions that can be done more effectively in bulk (specifically, those involving wiki page edits) are buffered and performed at the end of a pass through the reports. However, each buffer only covers a concrete action associated with a specific configuration rule. Accordingly, multiple API calls are sometimes made in order to make consecutive updates to a single page.

This change changes the buffering scheme so that all actions associated with a specific page can be performed at once, avoiding multiple API calls. As an added bonus, I've worked in a helper function that allows us to properly handle HTTP Conflict responses.

Before merging:

* [x] Fix tests. Include system tests verifying that configuration files work as intended. This will make tests more flexible for future changes in architecture.
* [x] Set up CI. Might as well start doing things right.
* [ ] Settle on some better terminology. "Actors" should become "rules," "subactors" "actors," and "ledgers" should probably just be "buffer" of "ActionBuffer" or similar.
* [x] The new concurrency-safe update function requires a newer version of prawcore that isn't compatible with the latest release of PRAW. It shouldn't be too long before it's backported, however. **Update:** I've decided to just pin to the latest development version for the time being.