### PR TITLE
Buffer individual Nuker comment removals

### DIFF
--- a/bernard/action_queue.py
+++ b/bernard/action_queue.py
@@ -1,7 +1,0 @@
-import heapq
-class ActionQueue:
-    def __init__(self):
-        self.actions = []
-
-    def insert(self, action, priority):
-

--- a/bernard/action_queue.py
+++ b/bernard/action_queue.py
@@ -1,0 +1,7 @@
+import heapq
+class ActionQueue:
+    def __init__(self):
+        self.actions = []
+
+    def insert(self, action, priority):
+

--- a/bernard/actors.py
+++ b/bernard/actors.py
@@ -412,16 +412,16 @@ class ToolboxNoteAdder(Actor):
             return 'l,{submission_id},{comment_id}'.format(
                 submission_id=thing.submission.id, comment_id=thing.id)
 
-    def __init__(self, text, level, buffer, *args, **kwargs):
+    def __init__(self, text, level, action_buffer, *args, **kwargs):
         """Initialize the ToolboxNoteAdder class."""
         super().__init__(*args, **kwargs)
         self.text = text
         self.level = level
-        self.buffer = buffer
+        self.action_buffer = action_buffer
 
     def action(self, post, mod):
         """Enqueue a note to add after pass through the reports."""
-        self.buffer.add(
+        self.action_buffer.add(
             BufferedNote(
                 str(post.author), self.level,
                 self.toolbox_link_string(post), mod, self.text,
@@ -487,11 +487,11 @@ class AutomodWatcher(Actor):
     ACTION_BUFFER = AutomodWatcherActionBuffer
     REQUIRED_TYPES = {'placeholder': str}
 
-    def __init__(self, placeholder, buffer, *args, **kwargs):
+    def __init__(self, placeholder, action_buffer, *args, **kwargs):
         """Initialize the AutomodWatcher class."""
         super().__init__(*args, **kwargs)
         self.placeholder = placeholder
-        self.buffer = buffer
+        self.action_buffer = action_buffer
 
     def _get_item(self, post):
         """Return item to add to automod."""
@@ -503,7 +503,7 @@ class AutomodWatcher(Actor):
         Actual wiki update performed in AutomodWatcherActionBuffer.after.
 
         """
-        self.buffer.add(self.placeholder, self._get_item(post))
+        self.action_buffer.add(self.placeholder, self._get_item(post))
 
 
 class AutomodDomainWatcher(AutomodWatcher):

--- a/bernard/loader.py
+++ b/bernard/loader.py
@@ -66,7 +66,9 @@ def parse_actor_config(subreddit, action_buffer_builder, config, target_types):
     params = config.params
     validate_actor_config(actor_class, params, target_types)
     if hasattr(actor_class, 'ACTION_BUFFER'):
-        params['buffer'] = action_buffer_builder.get(actor_class.ACTION_BUFFER)
+        params['action_buffer'] = action_buffer_builder.get(
+            actor_class.ACTION_BUFFER
+        )
     return actor_class(subreddit=subreddit, **params)
 
 

--- a/test/test_actors.py
+++ b/test/test_actors.py
@@ -89,7 +89,8 @@ class TestNotifier(BJOTest):
 
 class TestNuker(BJOTest):
     def test_action(self):
-        actor = actors.Nuker(self.subreddit)
+        action_buffer = actors.NukerActionBuffer(self.subreddit)
+        actor = actors.Nuker(action_buffer, self.subreddit)
         post = self.r.comment(id='dbnpgmz')
         with self.recorder.use_cassette('TestNuker.test_action'):
             actor.action(post, 'TGB')


### PR DESCRIPTION
Fixes #31.

Rather than making my own ad hoc thread scheduler, I've simply added a `NukerActionBuffer` that allows for periodic pauses on large queues of comments.